### PR TITLE
Skip fields with missing enum types

### DIFF
--- a/steamworks-sys/build.rs
+++ b/steamworks-sys/build.rs
@@ -99,6 +99,9 @@ use libc::*;
         }
         let fty = {
             if fty.contains("enum") {
+                if fty.contains("::") {
+                    return None;
+                }
                 fty.trim_start_matches("enum ")
             } else if fty.contains("struct") {
                 fty.trim_start_matches("struct ")


### PR DESCRIPTION
This pr removes fields with enum types containing `::`.

The build currently skips generation of enums containing `::`, so this allows the built code to compile when they exist in the steam api's json. Ie the new code matches the existing:
```rust
for e in steam_api.enums {
    if e.enumname.contains("::") {
        continue;
    }
...
```

Maybe there's a better fix, this is just how I got it to compile.