### PR TITLE
Add stats & achievements API

### DIFF
--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+/// Callback type after calling
+/// [`request_current_stats()`](struct.UserStats.html#method.request_current_stats).
+///
+/// # Example
+///
+/// ```no_run
+/// # use steamworks::*;
+/// # let (client, single) = steamworks::Client::init().unwrap();
+/// let callback_handle = client.register_callback(|val: UserStatsReceived| {
+///     if val.result.is_err() {
+///         // ...
+///     }
+/// });
+/// ```
+#[derive(Debug)]
+pub struct UserStatsReceived {
+    pub steam_id: SteamId,
+    pub game_id: GameId,
+    pub result: Result<(), SteamError>,
+}
+
+unsafe impl Callback for UserStatsReceived {
+    const ID: i32 = CALLBACK_BASE_ID + 1;
+    const SIZE: i32 = std::mem::size_of::<sys::UserStatsReceived_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+        let val = &mut *(raw as *mut sys::UserStatsReceived_t);
+        Self {
+            steam_id: SteamId(val.m_steamIDUser.0),
+            game_id: GameId(val.m_nGameID),
+            result: match val.m_eResult {
+                sys::EResult::EResultOK => Ok(()),
+                err => Err(err.into()),
+            },
+        }
+    }
+}
+
+/// Callback triggered by [`store()`](stats/struct.StatsHelper.html#method.store).
+///
+/// # Example
+///
+/// ```no_run
+/// # use steamworks::*;
+/// # let (client, single) = steamworks::Client::init().unwrap();
+/// let callback_handle = client.register_callback(|val: UserStatsStored| {
+///     if val.result.is_err() {
+///         // ...
+///     }
+/// });
+/// ```
+#[derive(Debug)]
+pub struct UserStatsStored {
+    pub game_id: GameId,
+    pub result: Result<(), SteamError>,
+}
+
+unsafe impl Callback for UserStatsStored {
+    const ID: i32 = CALLBACK_BASE_ID + 2;
+    const SIZE: i32 = std::mem::size_of::<sys::UserStatsStored_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+        let val = &mut *(raw as *mut sys::UserStatsStored_t);
+        Self {
+            game_id: GameId(val.m_nGameID),
+            result: match val.m_eResult {
+                sys::EResult::EResultOK => Ok(()),
+                err => Err(err.into()),
+            },
+        }
+    }
+}
+
+/// Result of a request to store the achievements on the server, or an "indicate progress" call.
+/// If both `current_progress` and `max_progress` are zero, that means the achievement has been
+/// fully unlocked.
+///
+/// # Example
+///
+/// ```no_run
+/// # use steamworks::*;
+/// # let (client, single) = steamworks::Client::init().unwrap();
+/// let callback_handle = client.register_callback(|val: UserAchievementStored| {
+///     // ...
+/// });
+/// ```
+#[derive(Debug)]
+pub struct UserAchievementStored {
+    pub game_id: GameId,
+    pub achievement_name: String,
+    /// Current progress towards the achievement.
+    pub current_progress: u32,
+    /// The total amount of progress required to unlock.
+    pub max_progress: u32,
+}
+
+unsafe impl Callback for UserAchievementStored {
+    const ID: i32 = CALLBACK_BASE_ID + 3;
+    const SIZE: i32 = std::mem::size_of::<sys::UserAchievementStored_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+        let val = &mut *(raw as *mut sys::UserAchievementStored_t);
+        let name = CStr::from_ptr(val.m_rgchAchievementName.as_ptr()).to_owned();
+        Self {
+            game_id: GameId(val.m_nGameID),
+            achievement_name: name.into_string().unwrap(),
+            current_progress: val.m_nCurProgress,
+            max_progress: val.m_nMaxProgress,
+        }
+    }
+}

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -1,0 +1,80 @@
+use super::*;
+
+/// Achievement API.
+///
+/// Methods require
+/// [`request_current_stats()`](../struct.UserStats.html#method.request_current_stats)
+/// to have been called and a successful [`UserStatsReceived`](../struct.UserStatsReceived.html)
+/// callback processed.
+///
+/// # Example
+///
+/// ```no_run
+/// # use steamworks::*;
+/// # let (client, single) = steamworks::Client::init().unwrap();
+/// // Unlock the 'WIN_THE_GAME' achievement
+/// client.user_stats().achievement("WIN_THE_GAME").set()?;
+/// # Err(())
+/// ```
+pub struct AchievementHelper<'parent, M> {
+    pub(crate) name: CString,
+    pub(crate) parent: &'parent UserStats<M>,
+}
+
+impl<M> AchievementHelper<'_, M> {
+    /// Gets the unlock status of the Achievement.
+    ///
+    /// This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock
+    /// status to the server and to trigger the Steam overlay notification you must call
+    /// [`store_stats()`](../struct.UserStats.html#method.store_stats).
+    ///
+    /// Fails if this achievement's 'API Name' is unknown, or unsuccessful
+    /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
+    pub fn get(&self) -> Result<bool, ()> {
+        unsafe {
+            let mut achieved = false;
+            let success = sys::SteamAPI_ISteamUserStats_GetAchievement(
+                self.parent.user_stats,
+                self.name.as_ptr() as *const _,
+                &mut achieved as *mut _,
+            );
+            if success { Ok(achieved) } else { Err(()) }
+        }
+    }
+
+    /// Unlocks an achievement.
+    ///
+    /// This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock
+    /// status to the server and to trigger the Steam overlay notification you must call
+    /// [`store_stats()`](../struct.UserStats.html#method.store_stats).
+    ///
+    /// Fails if this achievement's 'API Name' is unknown, or unsuccessful
+    /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
+    pub fn set(&self) -> Result<(), ()> {
+        let success = unsafe {
+            sys::SteamAPI_ISteamUserStats_SetAchievement(
+                self.parent.user_stats,
+                self.name.as_ptr() as *const _,
+            )
+        };
+        if success { Ok(()) } else { Err(()) }
+    }
+
+    /// Resets the unlock status of an achievement.
+    ///
+    /// This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock
+    /// status to the server and to trigger the Steam overlay notification you must call
+    /// [`store_stats()`](../struct.UserStats.html#method.store_stats).
+    ///
+    /// Fails if this achievement's 'API Name' is unknown, or unsuccessful
+    /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
+    pub fn clear(&self) -> Result<(), ()> {
+        let success = unsafe {
+            sys::SteamAPI_ISteamUserStats_ClearAchievement(
+                self.parent.user_stats,
+                self.name.as_ptr() as *const _,
+            )
+        };
+        if success { Ok(()) } else { Err(()) }
+    }
+}

--- a/steamworks-sys/src/lib.rs
+++ b/steamworks-sys/src/lib.rs
@@ -151,6 +151,39 @@ extern "C" {
     pub fn SteamAPI_ISteamUserStats_DownloadLeaderboardEntries(instance: *mut ISteamUserStats, leaderboard: SteamLeaderboard_t, data_request: ELeaderboardDataRequest, start: c_int, end: c_int) -> SteamAPICall_t;
     pub fn SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry(instance: *mut ISteamUserStats, entries: SteamLeaderboardEntries_t, index: c_int, entry: *mut LeaderboardEntry_t, details: *mut i32, details_max: c_int) -> u8;
 
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#RequestCurrentStats
+    ///
+    /// Returns true if successful
+    pub fn SteamAPI_ISteamUserStats_RequestCurrentStats(
+        instance: *mut ISteamUserStats,
+    ) -> bool;
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#GetAchievement
+    ///
+    /// Returns true if successful
+    pub fn SteamAPI_ISteamUserStats_GetAchievement(
+        instance: *mut ISteamUserStats,
+        name: *const c_char,
+        achieved: *mut bool,
+    ) -> bool;
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#SetAchievement
+    ///
+    /// Returns true if successful
+    pub fn SteamAPI_ISteamUserStats_SetAchievement(
+        instance: *mut ISteamUserStats,
+        name: *const c_char,
+    ) -> bool;
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#ClearAchievement
+    ///
+    /// Returns true if successful
+    pub fn SteamAPI_ISteamUserStats_ClearAchievement(
+        instance: *mut ISteamUserStats,
+        name: *const c_char,
+    ) -> bool;
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#StoreStats
+    ///
+    /// Returns true if successful
+    pub fn SteamAPI_ISteamUserStats_StoreStats(instance: *mut ISteamUserStats) -> bool;
+
     pub fn SteamAPI_ISteamGameServer_LogOnAnonymous(instance: *mut ISteamGameServer);
     pub fn SteamAPI_ISteamGameServer_SetProduct(instance: *mut ISteamGameServer, product: *const c_char);
     pub fn SteamAPI_ISteamGameServer_SetGameDescription(instance: *mut ISteamGameServer, description: *const c_char);


### PR DESCRIPTION
This pr adds wrappers for the achievements flow:

* `RequestCurrentStats`
* `{Get,Set,Clear}Achievement`
* `StoreStats`

Plus associated callback types. I also fixed some `c_char` binding issues as a new callback includes a `c_char` array.

I'll be using this API in Robo Instructus.

```rust
let user_stats = client.user_stats();
user_stats.request_current_stats();

// run callbacks

user_stats.achievement("WIN_THE_GAME").set()?;
user_stats.store_stats()?;
```