### PR TITLE
Update build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ failure = "0.1.5"
 bitflags = "1.0.4"
 libc = "0.2.50"
 lazy_static = "1.3.0"
+
+[dev-dependencies]
+serial_test = "0.2.0"
+serial_test_derive = "0.2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -78,7 +78,7 @@ impl <Manager> Apps<Manager> {
         }
     }
 
-    /// Returns the buildid of this app.
+    /// Returns the build id of this app.
     pub fn app_build_id(&self) -> i32 {
         unsafe {
             sys::SteamAPI_ISteamApps_GetAppBuildId(self.apps) as i32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,10 @@ impl GameId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test_derive::serial;
+
     #[test]
+    #[serial]
     fn basic_test() {
         let (client, single) = Client::init().unwrap();
 

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -13,7 +13,7 @@ const CALLBACK_BASE_ID: i32 = 500;
 pub enum LobbyType {
     Private,
     FriendsOnly,
-    Public ,
+    Public,
     Invisible,
 }
 

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1,5 +1,6 @@
-
 use super::*;
+#[cfg(test)]
+use serial_test_derive::serial;
 
 /// Access to the steam matchmaking interface
 pub struct Matchmaking<Manager> {
@@ -164,6 +165,7 @@ impl <Manager> Matchmaking<Manager> {
 }
 
 #[test]
+#[serial]
 fn test_lobby() {
     let (client, single) = Client::init().unwrap();
     let mm = client.matchmaking();

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(test)]
+use serial_test_derive::serial;
 
 /// Access to the steam remote storage interface
 pub struct RemoteStorage<Manager> {
@@ -257,6 +259,7 @@ pub struct SteamFileInfo {
 }
 
 #[test]
+#[serial]
 fn test_cloud() {
     use std::io::{Write, Read};
     let (client, _single) = Client::init().unwrap();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use super::*;
-
 use std::net::Ipv4Addr;
+#[cfg(test)]
+use serial_test_derive::serial;
 
 /// The main entry point into the steam client for servers.
 ///
@@ -234,6 +235,7 @@ impl Server {
 }
 
 #[test]
+#[serial]
 fn test() {
     let (server, single) = Server::init(
         [127, 0, 0, 1].into(),

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,6 @@
-
 use super::*;
+#[cfg(test)]
+use serial_test_derive::serial;
 
 /// Access to the steam user interface
 pub struct User<Manager> {
@@ -106,6 +107,7 @@ pub enum AuthSessionError {
 }
 
 #[test]
+#[serial]
 fn test() {
     let (client, single) = Client::init().unwrap();
     let user = client.user();

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -3,6 +3,8 @@ mod stat_callback;
 
 pub use self::stat_callback::*;
 use super::*;
+#[cfg(test)]
+use serial_test_derive::serial;
 
 /// Access to the steam user interface
 pub struct UserStats<Manager> {
@@ -216,6 +218,7 @@ pub enum LeaderboardDisplayType {
 pub struct Leaderboard(u64);
 
 #[test]
+#[serial]
 fn test() {
     let (client, single) = Client::init().unwrap();
 

--- a/steamworks-sys/build.rs
+++ b/steamworks-sys/build.rs
@@ -9,6 +9,7 @@ struct SteamApi {
     structs: Vec<SteamStruct>,
     enums: Vec<SteamEnum>,
 }
+
 #[derive(Deserialize)]
 struct SteamTypedef {
     typedef: String,
@@ -246,6 +247,8 @@ pub struct {} {{"#, packing, derive, s.struct_)?;
         fs::copy(link_path.join(&file_name), out_path.join(file_name))?;
     } else if triple.contains("darwin") {
         fs::copy(link_path.join("libsteam_api.dylib"), out_path.join("libsteam_api.dylib"))?;
+    } else if triple.contains("linux") {
+        fs::copy(link_path.join("libsteam_api.so"), out_path.join("libsteam_api.so"))?;
     }
 
     let mut compiler = cc::Build::new();
@@ -253,7 +256,7 @@ pub struct {} {{"#, packing, derive, s.struct_)?;
         .cpp(true)
         .include(sdk_loc.join("public/steam"))
         .file("src/lib.cpp");
-    if triple.contains("darwin") {
+    if triple.contains("darwin") || triple.contains("linux") {
         compiler.flag("-std=c++11");
     }
     compiler.compile("steamrust");


### PR DESCRIPTION
I don't know why it worked for you and not me but I'm guessing it's because Valve released a new version of their SDK: `v1.45 25th June 2019`. Whatever it is that changed, I updated the build script so it works on all 3 target platforms now. There were 3 main issues:

* The C++ source code wouldn't compile on Unix without C++11 explicitly enabled.
* The compiled code couldn't find "libsteam_api.dll" (or .so or .dylib) so the solution I found was to just copy it into the output directory. If there's a better way to do this, I'd like to hear it.
* Steamworks doesn't have an "osx64" folder anymore. They renamed it to "osx" I assume because Apple dropped support for 32-bittiness.

I also added the `serial_test` derive macros to make all of the tests run sequentially instead of in parallel because the SDK only runs one instance per process. If you use unrelated Client instances created in separate test threads, they conflict with each other and cause errors on Mac OS and segfaults on Windows.
