### PR TITLE
Added serde traits and other common traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ failure = "0.1.5"
 bitflags = "1.0.4"
 libc = "0.2.50"
 lazy_static = "1.3.0"
-serde = {version = "1.0", features = ["derive"]}
+serde = {version = "1.0", features = ["derive"], optional = true}
 
 [dev-dependencies]
 serial_test = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ failure = "0.1.5"
 bitflags = "1.0.4"
 libc = "0.2.50"
 lazy_static = "1.3.0"
+serde = {version = "1.0", features = ["derive"]}
 
 [dev-dependencies]
 serial_test = "0.2.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 /// An id for a steam app/game
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AppId(pub u32);
 
 /// Access to the steam apps interface

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// An id for a steam app/game
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppId(pub u32);
 
 /// Access to the steam apps interface

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -39,11 +39,11 @@ impl <Manager> Drop for CallbackHandle<Manager> {
 
 fn print_err(err: Box<dyn Any>) {
     if let Some(err) = err.downcast_ref::<&str>() {
-        println!("Steam callback paniced: {}", err);
+        println!("Steam callback panicked: {}", err);
     } else if let Some(err) = err.downcast_ref::<String>() {
-        println!("Steam callback paniced: {}", err);
+        println!("Steam callback panicked: {}", err);
     } else {
-        println!("Steam callback paniced");
+        println!("Steam callback panicked");
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,11 @@
+use serde::{Serialize, Deserialize};
 use crate::sys;
 
 /// Covers errors that can be returned by the steamworks API
 ///
 /// Documentation is based on official documentation which doesn't
 /// always explain when an error could be returned or its meaning.
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SteamError {
     /// Returned if the steamworks API fails to initialize.
     #[fail(display = "failed to init the steamworks API")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,14 @@
+#[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
+
 use crate::sys;
 
 /// Covers errors that can be returned by the steamworks API
 ///
 /// Documentation is based on official documentation which doesn't
 /// always explain when an error could be returned or its meaning.
-#[derive(Debug, Fail, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Fail, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SteamError {
     /// Returned if the steamworks API fails to initialize.
     #[fail(display = "failed to init the steamworks API")]

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -5,7 +5,7 @@ use std::net::Ipv4Addr;
 const CALLBACK_BASE_ID: i32 = 300;
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
     pub struct FriendFlags: u16 {
         const NONE                  = 0x0000;
@@ -27,7 +27,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Serialize, Deserialize)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
     pub struct PersonaChange: i32 {
         const NAME                = 0x0001;
@@ -115,7 +115,8 @@ impl <Manager> Friends<Manager> {
 }
 
 /// Information about a friend's current state in a game
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FriendGame {
     /// The id of the game that the friend is
     /// playing
@@ -130,7 +131,8 @@ pub struct FriendGame {
     pub lobby: LobbyId,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PersonaStateChange {
     pub steam_id: SteamId,
     pub flags: PersonaChange,
@@ -149,7 +151,8 @@ unsafe impl Callback for PersonaStateChange {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GameLobbyJoinRequested {
     pub lobby_steam_id: LobbyId,
     pub friend_steam_id: SteamId,

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -5,6 +5,7 @@ use std::net::Ipv4Addr;
 const CALLBACK_BASE_ID: i32 = 300;
 
 bitflags! {
+    #[derive(Serialize, Deserialize)]
     #[repr(C)]
     pub struct FriendFlags: u16 {
         const NONE                  = 0x0000;
@@ -26,6 +27,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Serialize, Deserialize)]
     #[repr(C)]
     pub struct PersonaChange: i32 {
         const NAME                = 0x0001;
@@ -113,7 +115,7 @@ impl <Manager> Friends<Manager> {
 }
 
 /// Information about a friend's current state in a game
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FriendGame {
     /// The id of the game that the friend is
     /// playing
@@ -128,7 +130,7 @@ pub struct FriendGame {
     pub lobby: LobbyId,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PersonaStateChange {
     pub steam_id: SteamId,
     pub flags: PersonaChange,
@@ -147,7 +149,7 @@ unsafe impl Callback for PersonaStateChange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GameLobbyJoinRequested {
     pub lobby_steam_id: LobbyId,
     pub friend_steam_id: SteamId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,13 +34,14 @@ pub use crate::remote_storage::*;
 mod ugc;
 pub use crate::ugc::*;
 
-use std::sync::{ Arc, Mutex };
+use std::sync::{Arc, Mutex};
 use std::ffi::{CString, CStr};
 use std::fmt::{
     Debug, Formatter, self
 };
 use std::marker::PhantomData;
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 pub type SResult<T> = Result<T, SteamError>;
 
@@ -149,7 +150,7 @@ impl Client<ClientManager> {
         }
     }
 }
-impl <M> SingleClient<M> where M: Manager{
+impl <M> SingleClient<M> where M: Manager {
     /// Runs any currently pending callbacks
     ///
     /// This runs all currently pending callbacks on the current
@@ -308,7 +309,7 @@ impl <Manager> Drop for Inner<Manager> {
     }
 }
 
-/// Used to seperate client and game server modes
+/// Used to separate client and game server modes
 pub unsafe trait Manager {
     unsafe fn run_callbacks();
 }
@@ -333,7 +334,7 @@ impl Drop for ClientManager {
 }
 
 /// A user's steam id
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SteamId(pub(crate) u64);
 
 impl SteamId {
@@ -369,13 +370,13 @@ impl SteamId {
 }
 
 /// A user's account id
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct AccountId(pub(crate) u32);
 
 /// A game id
 ///
 /// Combines `AppId` and other information
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GameId(pub(crate) u64);
 
 impl GameId {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ use std::fmt::{
 };
 use std::marker::PhantomData;
 use std::collections::HashMap;
+
+#[cfg(feature = "serde")]
 use serde::{Serialize, Deserialize};
 
 pub type SResult<T> = Result<T, SteamError>;
@@ -334,7 +336,8 @@ impl Drop for ClientManager {
 }
 
 /// A user's steam id
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamId(pub(crate) u64);
 
 impl SteamId {
@@ -370,13 +373,15 @@ impl SteamId {
 }
 
 /// A user's account id
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AccountId(pub(crate) u32);
 
 /// A game id
 ///
 /// Combines `AppId` and other information
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GameId(pub(crate) u64);
 
 impl GameId {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -11,7 +11,8 @@ pub struct Matchmaking<Manager> {
 const CALLBACK_BASE_ID: i32 = 500;
 
 /// The visibility of a lobby
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LobbyType {
     Private,
     FriendsOnly,
@@ -19,7 +20,8 @@ pub enum LobbyType {
     Invisible,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LobbyId(pub(crate) u64);
 
 impl LobbyId {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -11,6 +11,7 @@ pub struct Matchmaking<Manager> {
 const CALLBACK_BASE_ID: i32 = 500;
 
 /// The visibility of a lobby
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum LobbyType {
     Private,
     FriendsOnly,
@@ -18,7 +19,7 @@ pub enum LobbyType {
     Invisible,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct LobbyId(pub(crate) u64);
 
 impl LobbyId {
@@ -65,7 +66,8 @@ impl <Manager> Matchmaking<Manager> {
                         }
                         Ok(out)
                     })
-            });
+                }
+            );
         }
     }
 
@@ -101,7 +103,8 @@ impl <Manager> Matchmaking<Manager> {
                     } else {
                         Ok(LobbyId(v.m_ulSteamIDLobby))
                     })
-            });
+                }
+            );
         }
     }
 
@@ -121,7 +124,8 @@ impl <Manager> Matchmaking<Manager> {
                     } else {
                         Ok(LobbyId(v.m_ulSteamIDLobby))
                     })
-            });
+                }
+            );
         }
     }
 

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -7,7 +7,7 @@ pub struct Networking<Manager> {
 }
 
 /// The method used to send a packet
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SendType {
     /// Send the packet directly over udp.
     ///
@@ -89,7 +89,7 @@ impl <Manager> Networking<Manager> {
 }
 
 /// Called when a user wants to communicate via p2p
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct P2PSessionRequest {
     /// The steam ID of the user requesting a p2p
     /// session

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -7,7 +7,8 @@ pub struct Networking<Manager> {
 }
 
 /// The method used to send a packet
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SendType {
     /// Send the packet directly over udp.
     ///
@@ -89,7 +90,8 @@ impl <Manager> Networking<Manager> {
 }
 
 /// Called when a user wants to communicate via p2p
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct P2PSessionRequest {
     /// The steam ID of the user requesting a p2p
     /// session

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -250,7 +250,8 @@ impl <Manager> std::io::Seek for SteamFileReader<Manager> {
 }
 
 /// Name and size information about a file in the steam cloud
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamFileInfo {
     /// The file name
     pub name: String,

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -250,7 +250,7 @@ impl <Manager> std::io::Seek for SteamFileReader<Manager> {
 }
 
 /// Name and size information about a file in the steam cloud
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SteamFileInfo {
     /// The file name
     pub name: String,

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,7 +71,7 @@ impl Server {
                 raw_ip, steam_port,
                 game_port, query_port,
                 server_mode,
-                version.as_ptr() as *const _,
+                version.as_ptr(),
             ) == 0 {
                 return Err(SteamError::InitFailed);
             }

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -20,7 +20,8 @@ const CALLBACK_REMOTE_STORAGE_BASE_ID: i32 = 1300;
 const UGCQueryHandleInvalid: u64 = 0xffffffffffffffff;
 
 /// Worshop item ID
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PublishedFileId(pub u64);
 
 /// Workshop item types to search for

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -20,7 +20,7 @@ const CALLBACK_REMOTE_STORAGE_BASE_ID: i32 = 1300;
 const UGCQueryHandleInvalid: u64 = 0xffffffffffffffff;
 
 /// Worshop item ID
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct PublishedFileId(pub u64);
 
 /// Workshop item types to search for

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -177,7 +177,8 @@ impl <Manager> UserStats<Manager> {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LeaderboardEntry {
     pub user: SteamId,
     pub global_rank: i32,
@@ -191,7 +192,8 @@ pub enum LeaderboardDataRequest {
     Friends,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LeaderboardScoreUploaded {
     pub score: i32,
     pub was_changed: bool,
@@ -199,26 +201,30 @@ pub struct LeaderboardScoreUploaded {
     pub global_rank_previous: i32,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum UploadScoreMethod {
     KeepBest,
     ForceUpdate,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LeaderboardSortMethod {
     Ascending,
     Descending,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LeaderboardDisplayType {
     Numeric,
     TimeSeconds,
     TimeMilliSeconds,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Leaderboard(u64);
 
 #[test]

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -68,7 +68,8 @@ impl <Manager> UserStats<Manager> {
                             None
                         })
                     })
-            });
+                }
+            );
         }
     }
 
@@ -103,11 +104,11 @@ impl <Manager> UserStats<Manager> {
     }
 
     pub fn download_leaderboard_entries<F>(
-            &self,
-            leaderboard: &Leaderboard,
-            request: LeaderboardDataRequest, start: usize, end: usize,
-            max_details_len: usize,
-            mut cb: F
+        &self,
+        leaderboard: &Leaderboard,
+        request: LeaderboardDataRequest, start: usize, end: usize,
+        max_details_len: usize,
+        mut cb: F
     )
         where F: FnMut(Result<Vec<LeaderboardEntry>, SteamError>) + 'static + Send + Sync
     {
@@ -176,7 +177,7 @@ impl <Manager> UserStats<Manager> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LeaderboardEntry {
     pub user: SteamId,
     pub global_rank: i32,
@@ -190,7 +191,7 @@ pub enum LeaderboardDataRequest {
     Friends,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LeaderboardScoreUploaded {
     pub score: i32,
     pub was_changed: bool,
@@ -198,23 +199,26 @@ pub struct LeaderboardScoreUploaded {
     pub global_rank_previous: i32,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum UploadScoreMethod {
     KeepBest,
     ForceUpdate,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LeaderboardSortMethod {
     Ascending,
     Descending,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LeaderboardDisplayType {
     Numeric,
     TimeSeconds,
     TimeMilliSeconds,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Leaderboard(u64);
 
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,7 @@ pub enum NotificationPosition {
     BottomRight,
 }
 
-lazy_static!{
+lazy_static! {
     /// Global rust warning callback
     static ref WARNING_CALLBACK: RwLock<Option<Box<Fn(i32, &CStr) + Send + Sync>>> = RwLock::new(None);
 }
@@ -40,11 +40,11 @@ unsafe extern "cdecl" fn c_warning_callback(level: i32, msg: *const c_char) {
     ));
     if let Err(err) = res {
         if let Some(err) = err.downcast_ref::<&str>() {
-            println!("Steam warning callback paniced: {}", err);
+            println!("Steam warning callback panicked: {}", err);
         } else if let Some(err) = err.downcast_ref::<String>() {
-            println!("Steam warning callback paniced: {}", err);
+            println!("Steam warning callback panicked: {}", err);
         } else {
-            println!("Steam warning callback paniced");
+            println!("Steam warning callback panicked");
         }
         abort();
     }


### PR DESCRIPTION
I needed to send messages through an API that only works on byte buffers. Instead of wrapping everything in newtypes, it's better if oldtypes implement common interfaces. (More detailed guidelines here https://rust-lang-nursery.github.io/api-guidelines/interoperability.html but that's the basic gist of it.)

Also fixed some minor issues: formatting, typos, redundant cast.