### PR TITLE
Add ugc::QueryResults::iter_maybe

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -759,7 +759,7 @@ impl <Manager> UserListQuery<Manager> {
         }
 
         self.fetch(move |res|
-            cb(res.map(|qr| qr.iter().map(|v| PublishedFileId(v.published_file_id.0)).collect::<Vec<_>>())))
+            cb(res.map(|qr| qr.iter().filter_map(|v| v.map(|v| PublishedFileId(v.published_file_id.0))).collect::<Vec<_>>())))
     }
 }
 
@@ -881,13 +881,7 @@ impl<'a> QueryResults<'a> {
     }
 
     /// Returns an iterator that runs over all the fetched results
-    pub fn iter<'b>(&'b self) -> impl Iterator<Item=QueryResult> + 'b {
-        (0..self.returned_results())
-            .map(move |i| self.get(i).unwrap())
-    }
-
-    /// Returns an iterator that runs over all the fetched results, but doesn't panic if one of those results failed
-    pub fn iter_maybe<'b>(&'b self) -> impl Iterator<Item=Option<QueryResult>> + 'b {
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item=Option<QueryResult>> + 'b {
         (0..self.returned_results())
             .map(move |i| self.get(i))
     }

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -844,8 +844,7 @@ impl<'a> QueryResults<'a> {
             let ok = sys::SteamAPI_ISteamUGC_GetQueryUGCResult(self.ugc, self.handle, index, &mut raw_details);
             debug_assert!(ok);
 
-            // TODO: is this always true? we don't get this from an async call...
-            debug_assert!(raw_details.m_eResult == sys::EResult::k_EResultOK);
+            if raw_details.m_eResult != sys::EResult::k_EResultOK { return None }
 
             let tags = CStr::from_ptr(raw_details.m_rgchTags.as_ptr())
                 .to_string_lossy()
@@ -885,6 +884,12 @@ impl<'a> QueryResults<'a> {
     pub fn iter<'b>(&'b self) -> impl Iterator<Item=QueryResult> + 'b {
         (0..self.returned_results())
             .map(move |i| self.get(i).unwrap())
+    }
+
+    /// Returns an iterator that runs over all the fetched results, but doesn't panic if one of those results failed
+    pub fn iter_maybe<'b>(&'b self) -> impl Iterator<Item=Option<QueryResult>> + 'b {
+        (0..self.returned_results())
+            .map(move |i| self.get(i))
     }
 }
 


### PR DESCRIPTION
Resolves the problem when ugc::query_items returns an invalid result amongst its other results which causes a panic with ugc::QueryResults::iter.

I guess it's for backwards compatibility so we don't need to change ugc::QueryResults::iter.