### PR TITLE
Make request_user_information return the returned bool from Steamworks

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -91,9 +91,9 @@ impl <Manager> Friends<Manager> {
         }
     }
 
-    pub fn request_user_information(&self, user: SteamId, name_only: bool) {
+    pub fn request_user_information(&self, user: SteamId, name_only: bool) -> bool {
         unsafe {
-            sys::SteamAPI_ISteamFriends_RequestUserInformation(self.friends, user.0, name_only);
+            sys::SteamAPI_ISteamFriends_RequestUserInformation(self.friends, user.0, name_only)
         }
     }
 


### PR DESCRIPTION
Returns the bool from RequestUserInformation signifying if the data is already immediately available or not.