### PR TITLE
Rebuild `sys` crate whenever `STEAM_SDK_LOCATION` changes

### DIFF
--- a/steamworks-sys/Cargo.toml
+++ b/steamworks-sys/Cargo.toml
@@ -7,6 +7,7 @@ description = "Provides raw bindings to the steamworks sdk"
 license = "MIT / Apache-2.0"
 repository = "https://github.com/Thinkofname/steamworks-rs"
 documentation = "https://docs.rs/steamworks-sys"
+edition = "2018"
 
 [package.metadata.docs.rs]
 features = [ "docs-only" ]

--- a/steamworks-sys/Cargo.toml
+++ b/steamworks-sys/Cargo.toml
@@ -20,7 +20,6 @@ docs-only = []
 
 
 [dependencies]
-libc = "0.2.86"
 
 [build-dependencies]
 bindgen = "0.57.0"

--- a/steamworks-sys/build.rs
+++ b/steamworks-sys/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sdk_loc = env::var("STEAM_SDK_LOCATION")
         .expect("STEAM_SDK_LOCATION must be set");
     let sdk_loc = Path::new(&sdk_loc);
+    println!("cargo:rerun-if-env-changed=STEAM_SDK_LOCATION");
 
     let triple = env::var("TARGET").unwrap();
     let mut lib = "steam_api";

--- a/steamworks-sys/src/lib.rs
+++ b/steamworks-sys/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
 
-extern crate libc;
-
 #[cfg(not(feature = "docs-only"))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
This PR makes cargo rebuild the `sys` crate whenever `STEAM_SDK_LOCATION` changes, which helps solve some of the issues from #37. 

I also updated the crate to edition 2018 since that only required adding the appropriate line in the `Cargo.toml` and removing all `extern <crane-name>`s from `lib.rs`. I also removed `libc` from the `sys` crate since I don't think it was doing anything as its types were never re-exported. 

Looking over the library as a whole, I think it would be fairly trivial to remove the `libc` dependency entirely in favor of relying on std types. I can add it to this PR or create a new one if this is desired.