### PR TITLE
Remove `libc` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ members = [
 steamworks-sys = {path = "./steamworks-sys", version = "0.7.0"}
 thiserror = "1.0.24"
 bitflags = "1.2.1"
-libc = "0.2.86"
 lazy_static = "1.4.0"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-use libc::{ c_void };
 use crate::sys;
 
 use std::sync::{ Arc, Weak };

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -145,7 +145,7 @@ unsafe impl Callback for PersonaStateChange {
     const ID: i32 = CALLBACK_BASE_ID + 4;
     const SIZE: i32 = ::std::mem::size_of::<sys::PersonaStateChange_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::PersonaStateChange_t);
         PersonaStateChange {
             steam_id: SteamId(val.m_ulSteamID),
@@ -165,7 +165,7 @@ unsafe impl Callback for GameLobbyJoinRequested {
     const ID: i32 = CALLBACK_BASE_ID + 33;
     const SIZE: i32 = ::std::mem::size_of::<sys::GameLobbyJoinRequested_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GameLobbyJoinRequested_t);
         GameLobbyJoinRequested {
             lobby_steam_id: LobbyId(val.m_steamIDLobby.m_steamid.m_unAll64Bits),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-
-use libc;
 extern crate steamworks_sys as sys;
 #[macro_use]
 extern crate thiserror;
@@ -34,6 +32,7 @@ pub use crate::remote_storage::*;
 mod ugc;
 pub use crate::ugc::*;
 
+use core::ffi::c_void;
 use std::sync::{Arc, Mutex};
 use std::ffi::{CString, CStr};
 use std::fmt::{
@@ -82,8 +81,8 @@ struct Inner<Manager> {
 }
 
 struct Callbacks {
-    callbacks: HashMap<i32, Box<dyn FnMut(*mut libc::c_void) + Send + 'static>>,
-    call_results: HashMap<sys::SteamAPICall_t, Box<dyn FnOnce(*mut libc::c_void, bool) + Send + 'static>>,
+    callbacks: HashMap<i32, Box<dyn FnMut(*mut c_void) + Send + 'static>>,
+    call_results: HashMap<sys::SteamAPICall_t, Box<dyn FnOnce(*mut c_void, bool) + Send + 'static>>,
 }
 
 unsafe impl <Manager: Send + Sync> Send for Inner<Manager> {}

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -102,7 +102,7 @@ unsafe impl Callback for P2PSessionRequest {
     const ID: i32 = 1202;
     const SIZE: i32 = ::std::mem::size_of::<sys::P2PSessionRequest_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionRequest_t);
         P2PSessionRequest {
             remote: SteamId(val.m_steamIDRemote.m_steamid.m_unAll64Bits),
@@ -121,7 +121,7 @@ unsafe impl Callback for P2PSessionConnectFail {
     const ID: i32 = 1203;
     const SIZE: i32 = ::std::mem::size_of::<sys::P2PSessionConnectFail_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionConnectFail_t);
         P2PSessionConnectFail {
             remote: SteamId(val.m_steamIDRemote.m_steamid.m_unAll64Bits),

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::marker;
 use std::mem;
 use std::path::Path;
+use std::os::raw::c_char;
 
 pub struct UGC<Manager> {
     pub(crate) ugc: *mut sys::ISteamUGC,
@@ -274,7 +275,7 @@ unsafe impl Callback for Result<DownloadItemResult, SteamError> {
     const ID: i32 = CALLBACK_BASE_ID + 6;
     const SIZE: i32 = ::std::mem::size_of::<sys::DownloadItemResult_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::DownloadItemResult_t);
         if val.m_eResult == sys::EResult::k_EResultOK {
             Ok(DownloadItemResult {
@@ -414,7 +415,7 @@ impl <Manager> UGC<Manager> {
     pub fn item_install_info(&self, item: PublishedFileId) -> Option<InstallInfo> {
         unsafe {
             let mut size_on_disk = 0u64;
-            let mut folder = [0 as libc::c_char; 4096];
+            let mut folder = [0 as c_char; 4096];
             let mut timestamp = 0u32;
             if sys::SteamAPI_ISteamUGC_GetItemInstallInfo(self.ugc, item.0, &mut size_on_disk, folder.as_mut_ptr(), folder.len() as _, &mut timestamp) {
                 Some(InstallInfo {
@@ -1097,7 +1098,7 @@ impl<'a> QueryResults<'a> {
 
     /// Gets the preview URL of the published file at the specified index.
     pub fn preview_url(&self, index: u32) -> Option<String> {
-        let mut url = [0 as libc::c_char; 4096];
+        let mut url = [0 as c_char; 4096];
 
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_GetQueryUGCPreviewURL(self.ugc, self.handle, index, url.as_mut_ptr(), url.len() as _)

--- a/src/user.rs
+++ b/src/user.rs
@@ -156,7 +156,7 @@ unsafe impl Callback for AuthSessionTicketResponse {
     const ID: i32 = 163;
     const SIZE: i32 = ::std::mem::size_of::<sys::GetAuthSessionTicketResponse_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GetAuthSessionTicketResponse_t);
         AuthSessionTicketResponse {
             ticket: AuthTicket(val.m_hAuthTicket),
@@ -187,7 +187,7 @@ unsafe impl Callback for ValidateAuthTicketResponse {
     const ID: i32 = 143;
     const SIZE: i32 = ::std::mem::size_of::<sys::ValidateAuthTicketResponse_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::ValidateAuthTicketResponse_t);
         ValidateAuthTicketResponse {
             steam_id: SteamId(val.m_SteamID.m_steamid.m_unAll64Bits),

--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -25,7 +25,7 @@ unsafe impl Callback for UserStatsReceived {
     const ID: i32 = CALLBACK_BASE_ID + 1;
     const SIZE: i32 = std::mem::size_of::<sys::UserStatsReceived_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsReceived_t);
         Self {
             steam_id: SteamId(val.m_steamIDUser.m_steamid.m_unAll64Bits),
@@ -61,7 +61,7 @@ unsafe impl Callback for UserStatsStored {
     const ID: i32 = CALLBACK_BASE_ID + 2;
     const SIZE: i32 = std::mem::size_of::<sys::UserStatsStored_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsStored_t);
         Self {
             game_id: GameId(val.m_nGameID),
@@ -100,7 +100,7 @@ unsafe impl Callback for UserAchievementStored {
     const ID: i32 = CALLBACK_BASE_ID + 3;
     const SIZE: i32 = std::mem::size_of::<sys::UserAchievementStored_t>() as i32;
 
-    unsafe fn from_raw(raw: *mut libc::c_void) -> Self {
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserAchievementStored_t);
         let name = CStr::from_ptr(val.m_rgchAchievementName.as_ptr()).to_owned();
         Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 
 use super::*;
 
-use libc::c_char;
+use std::os::raw::c_char;
 use std::ffi::CStr;
 use std::panic;
 use std::process::abort;


### PR DESCRIPTION
As mentioned in #38, I tried to remove the `libc` dependency entirely from this library. This ended up being extremely straightforward, as the stdlib contains types that have a 1-1 correspondence with the used `libc` types.