### PR TITLE
Export `sys::kNumUGCResultsPerPage`

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -9,7 +9,7 @@ use std::mem;
 use std::path::Path;
 use std::os::raw::c_char;
 
-pub use sys::kNumUGCResultsPerPage as kNumUGCResultsPerPage;
+pub const RESULTS_PER_PAGE: u32 = sys::kNumUGCResultsPerPage as u32;
 
 pub struct UGC<Manager> {
     pub(crate) ugc: *mut sys::ISteamUGC,

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -9,6 +9,8 @@ use std::mem;
 use std::path::Path;
 use std::os::raw::c_char;
 
+pub use sys::kNumUGCResultsPerPage as kNumUGCResultsPerPage;
+
 pub struct UGC<Manager> {
     pub(crate) ugc: *mut sys::ISteamUGC,
     pub(crate) inner: Arc<Inner<Manager>>,


### PR DESCRIPTION
Useful for chunking paginated results.