### PR TITLE
Add `SteamServersConnected`, `SteamServersDisconnected` and `SteamServerConnectFailure` callbacks

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -209,6 +209,63 @@ unsafe impl Callback for ValidateAuthTicketResponse {
     }
 }
 
+/// Called when a connection to the Steam servers is made.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SteamServersConnected;
+
+unsafe impl Callback for SteamServersConnected {
+    const ID: i32 = 101;
+    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServersConnected_t>() as i32;
+
+    unsafe fn from_raw(_: *mut c_void) -> Self {
+        SteamServersConnected
+    }
+}
+
+/// Called when the connection to the Steam servers is lost.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SteamServersDisconnected {
+    /// The reason we were disconnected from the Steam servers
+    pub reason: SteamError
+}
+
+unsafe impl Callback for SteamServersDisconnected {
+    const ID: i32 = 103;
+    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServersDisconnected_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
+        let val = &mut *(raw as *mut sys::SteamServersDisconnected_t);
+        SteamServersDisconnected {
+            reason: val.m_eResult.into()
+        }
+    }
+}
+
+/// Called when the connection to the Steam servers fails.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct SteamServerConnectFailure {
+    /// The reason we failed to connect to the Steam servers
+    pub reason: SteamError,
+    /// Whether we are still retrying the connection.
+    pub still_retrying: bool,
+}
+
+unsafe impl Callback for SteamServerConnectFailure {
+    const ID: i32 = 102;
+    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServerConnectFailure_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
+        let val = &mut *(raw as *mut sys::SteamServerConnectFailure_t);
+        SteamServerConnectFailure {
+            reason: val.m_eResult.into(),
+            still_retrying: val.m_bStillRetrying
+        }
+    }
+}
+
 /// Errors from `ValidateAuthTicketResponse`
 #[derive(Debug, Error)]
 pub enum AuthSessionValidateError {


### PR DESCRIPTION
Have tested that they work - you can't just set your friends status as offline to test these callbacks, the Steam servers connection persists. Turning off your computer's networking executes the callbacks.