### PR TITLE
Fix details length setting with a minimum check

### DIFF
--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -198,7 +198,12 @@ impl UserStats {
                                 details.as_mut_ptr(),
                                 max_details_len as _,
                             );
-                            details.set_len(entry.m_cDetails as usize);
+                            
+                            details.set_len(
+                                std::cmp::min(
+                                    entry.m_cDetails as usize, 
+                                    max_details_len as usize)
+                            );
 
                             entries.push(LeaderboardEntry {
                                 user: SteamId(entry.m_steamIDUser.m_steamid.m_unAll64Bits),


### PR DESCRIPTION
It fixes a panic when steam was sending more data than usual. Fixes #286 