### PR TITLE
Added methods for workshop item playtime tracking 

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -502,6 +502,20 @@ impl_callback!(cb: DownloadItemResult_t => DownloadItemResult {
 
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DeleteItemResult {
+    pub published_file_id: PublishedFileId,
+    pub result: sys::EResult,
+}
+
+impl_callback!(cb: DeleteItemResult_t => DeleteItemResult {
+    Self {
+        published_file_id: PublishedFileId(cb.m_nPublishedFileId),
+        result: cb.m_eResult,
+    }
+});
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct InstallInfo {
     pub folder: String,
     pub size_on_disk: u64,


### PR DESCRIPTION
Hello, I help maintain a steamworks.js fork where I needed to have some extra workshop methods, and I noticed these methods were not implemented in this repo that steamworks.js depends on.

I am fairly new to Rust and I don't quite understand how the codebase works but looking at the rest of the file my added code makes sense to me and should hopefully work.

Please let me know if things need to be changed (or feel free to make the changes yourself)