### PR TITLE
Add language method to UpdateHandle

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -867,6 +867,19 @@ impl UpdateHandle {
     }
 
     #[must_use]
+    pub fn language(self, language: &str) -> Self {
+        unsafe {
+            let language = CString::new(language).unwrap();
+            assert!(sys::SteamAPI_ISteamUGC_SetItemUpdateLanguage(
+                self.ugc,
+                self.handle,
+                language.as_ptr()
+            ));
+        }
+        self
+    }
+
+    #[must_use]
     pub fn preview_path(self, path: &Path) -> Self {
         unsafe {
             let path = path.canonicalize().unwrap();


### PR DESCRIPTION
Adds a `language` method to `UpdateHandle` that allows setting the item update language via `SteamAPI_ISteamUGC_SetItemUpdateLanguage`. Enables specifying the language when updating UGC items.