### PR TITLE
Fix build errors for `aarch64-unknown-linux-gnu`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -754,7 +754,7 @@ impl SteamAPIInitError {
     ) -> Self {
         let err_string = unsafe {
             let cstr = CStr::from_ptr(message.as_ptr());
-            cstr.to_string_lossy().to_owned().into_owned()
+            cstr.to_string_lossy().into_owned()
         };
 
         match result {

--- a/src/input.rs
+++ b/src/input.rs
@@ -59,10 +59,10 @@ impl Input {
         let handles = controllers.as_mut();
         assert!(handles.len() >= sys::STEAM_INPUT_MAX_COUNT as usize);
         unsafe {
-            return sys::SteamAPI_ISteamInput_GetConnectedControllers(
+            sys::SteamAPI_ISteamInput_GetConnectedControllers(
                 self.input,
                 handles.as_mut_ptr(),
-            ) as usize;
+            ) as usize
         }
     }
 

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -153,14 +153,14 @@ impl Matchmaking {
 
     /// Returns the lobby metadata associated with the specified index
     pub fn lobby_data_by_index(&self, lobby: LobbyId, idx: u32) -> Option<(String, String)> {
-        let mut key = [0i8; sys::k_nMaxLobbyKeyLength as usize];
-        let mut value = [0i8; sys::k_cubChatMetadataMax as usize];
+        let mut key = [0 as c_char; sys::k_nMaxLobbyKeyLength as usize];
+        let mut value = [0 as c_char; sys::k_cubChatMetadataMax as usize];
         unsafe {
             let success = sys::SteamAPI_ISteamMatchmaking_GetLobbyDataByIndex(
                 self.mm,
                 lobby.0,
                 idx as _,
-                key.as_mut_ptr() as _,
+                key.as_mut_ptr() as *mut c_char,
                 key.len() as _,
                 value.as_mut_ptr() as _,
                 value.len() as _,

--- a/src/matchmaking_servers.rs
+++ b/src/matchmaking_servers.rs
@@ -123,8 +123,8 @@ macro_rules! gen_server_list_fn {
                         return Err(());
                     }
 
-                    let mut key = [0i8; 256];
-                    let mut value = [0i8; 256];
+                    let mut key = [0 as c_char; 256];
+                    let mut value = [0 as c_char; 256];
 
                     unsafe {
                         key.as_mut_ptr()

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 use serial_test::serial;
-use {super::*, ::core::mem::MaybeUninit};
+use {super::*};
 
 /// Access to the steam remote storage interface
 pub struct RemoteStorage {

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -150,7 +150,7 @@ impl AchievementHelper<'_> {
     ///
     /// - `request_current_stats()` has completed and successfully returned its callback.
     /// - The specified achievement exists in App Admin on the Steamworks website, and the
-    /// changes are published.
+    ///   changes are published.
     /// - The specified `pchKey` is valid.
     ///
     /// # Example

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -305,7 +305,7 @@ pub(crate) struct SteamParamStringArray(Vec<*mut i8>);
 impl Drop for SteamParamStringArray {
     fn drop(&mut self) {
         for c_string in &self.0 {
-            unsafe { drop(CString::from_raw(*c_string)) };
+            unsafe { drop(CString::from_raw(*c_string as *mut c_char)) };
         }
     }
 }
@@ -316,7 +316,7 @@ impl SteamParamStringArray {
                 .map(|s| {
                     CString::new(s.as_ref())
                         .expect("String passed could not be converted to a c string")
-                        .into_raw()
+                        .into_raw() as _
                 })
                 .collect(),
         )


### PR DESCRIPTION
Some of the steamworks-rs code uses u8/i8 where it should use c_char. This was quick-and-dirty patch job to get it building on arm64. I don't actually have an arm machine on-hand to test it natively, but it *does* compile. :+1: 