### PR TITLE
Copy libs next to target instead of OUT_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ Add the following to your `Cargo.toml`:
 steamworks = "0.12.0"
 ```
 
+### Extra note for Linux & MacOS linking
+Since Steamworks-rs loads the SDK dynamically, you need to tell the linker to look for the dynamic library next to your executable. You can do so by using a build script:
+
+Create a `build.rs` file next to your `Cargo.toml`:
+
+```rust
+fn main() {
+    #[cfg(target_os = "macos")]
+    println!("cargo::rustc-link-arg=-Wl,-rpath,@executable_path");
+
+    #[cfg(target_os = "linux")]
+    println!("cargo::rustc-link-arg=-Wl,-rpath,$ORIGIN");
+}
+
+```
+
 | Crate  | SDK   | MSRV   |
 | ------ | ----- | ------ |
 | git    | 1.62  | 1.80.0 |
@@ -76,4 +92,4 @@ This crate is dual-licensed under [Apache](./LICENSE-APACHE) and
 [MIT](./LICENSE-MIT), except for the files in [`steamworks-sys/lib/steam/`]
 
 ## Help, I can't run my game!
-If you are seeing errors like `STATUS_DLL_NOT_FOUND`, `Image not found` etc. You are likely missing the Steamworks SDK Redistributable files. Steamworks-rs loads the SDK dynamically, so the libraries need to exist somewhere the operating system can find them. This is likely next to your game binary (.exe on windows). You can find the required files in the SDK release ZIP, under `lib\steam\redistributable_bin`. See #63 for further details
+If you are seeing errors like `STATUS_DLL_NOT_FOUND`, `Image not found` etc. You are likely missing the Steamworks SDK Redistributable files. In this case, please make sure you ship the Steamworks dynamic library with your game. If you can not find the required files, you can download the SDK release ZIP, and find them under `lib\steam\redistributable_bin`. See #63 for further details

--- a/steamworks-sys/build.rs
+++ b/steamworks-sys/build.rs
@@ -6,7 +6,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::fs::{self};
     use std::path::{Path, PathBuf};
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_path = Path::new(&out_dir)
+        .ancestors()
+        .nth(3)
+        .expect("Could not find target directory")
+        .to_path_buf();
     let sdk_loc = if let Ok(sdk_loc) = env::var("STEAM_SDK_LOCATION") {
         Path::new(&sdk_loc).to_path_buf()
     } else {


### PR DESCRIPTION
Closes #63 

Obviously this seems hacky. Feel free to close if undesired. But a [quick search](https://github.com/search?q=new(%26out_dir).ancestors()&type=code) for `new(&out_dir).ancestors()` on github reveals that it isn't super rare to locate the target directory from OUT_DIR and cargo doesn't actually stop you from doing so.

Also added a note for setting up linker on *nix system. I only tested this on Linux machines.