### PR TITLE
Fixed NetworkingMessages session request/failure callbacks being immediately disposed of upon creation

### DIFF
--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -188,7 +188,7 @@ impl NetworkingMessages {
             message: self.net,
             inner: Arc::downgrade(&self.inner),
         };
-        unsafe {
+        let call_handle = unsafe {
             register_callback(
                 &self.inner,
                 move |request: NetworkingMessagesSessionRequest| {
@@ -196,8 +196,9 @@ impl NetworkingMessages {
                         callback(request);
                     }
                 },
-            );
-        }
+            )
+        };
+        std::mem::forget(call_handle);
     }
 
     /// Register a callback that will be called whenever a connection fails to be established.
@@ -208,14 +209,15 @@ impl NetworkingMessages {
         &self,
         mut callback: impl FnMut(NetConnectionInfo) + Send + 'static,
     ) {
-        unsafe {
+        let call_handle = unsafe {
             register_callback(
                 &self.inner,
                 move |failed: NetworkingMessagesSessionFailed| {
                     callback(failed.info);
                 },
-            );
-        }
+            )
+        };
+        std::mem::forget(call_handle);
     }
 
     /// Get information about the status of a connection to a remote host.


### PR DESCRIPTION
In the current version, when you create a network socket, you are unable to ever accept/reject a connection because the handle of `register_callback()` is immediately dropped, removing the callback when the register methods return.

This patch prevents its Drop impl being run automatically, restoring the behaviour as described by the doc comments on these methods.