### PR TITLE
Fix message_buffer under-allocation in receive_messages

### DIFF
--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -940,8 +940,10 @@ impl NetConnection {
         batch_size: usize,
     ) -> Result<Vec<NetworkingMessage>, InvalidHandle> {
         if self.message_buffer.capacity() < batch_size {
-            self.message_buffer
-                .reserve(batch_size - self.message_buffer.capacity());
+            // reserve(additional) ensures capacity >= len + additional.
+            // Since the buffer is always drained between calls, len == 0,
+            // so reserve(batch_size) guarantees capacity >= batch_size.
+            self.message_buffer.reserve(batch_size);
         }
 
         self.receive_messages_internal(batch_size)?;
@@ -963,8 +965,10 @@ impl NetConnection {
         batch_size: usize,
     ) -> Result<(), InvalidHandle> {
         if self.message_buffer.capacity() < batch_size {
-            self.message_buffer
-                .reserve(batch_size - self.message_buffer.capacity());
+            // reserve(additional) ensures capacity >= len + additional.
+            // Since the buffer is always drained between calls, len == 0,
+            // so reserve(batch_size) guarantees capacity >= batch_size.
+            self.message_buffer.reserve(batch_size);
         }
 
         self.receive_messages_internal(batch_size)?;
@@ -1106,8 +1110,10 @@ unsafe impl Sync for NetPollGroup {}
 impl NetPollGroup {
     pub fn receive_messages(&mut self, batch_size: usize) -> Vec<NetworkingMessage> {
         if self.message_buffer.capacity() < batch_size {
-            self.message_buffer
-                .reserve(batch_size - self.message_buffer.capacity());
+            // reserve(additional) ensures capacity >= len + additional.
+            // Since the buffer is always drained between calls, len == 0,
+            // so reserve(batch_size) guarantees capacity >= batch_size.
+            self.message_buffer.reserve(batch_size);
         }
 
         unsafe {


### PR DESCRIPTION
## What

Fixes a buffer under-allocation bug in `NetConnection::receive_messages`, `receive_messages_into`, and `NetPollGroup::receive_messages`.

## Why

The old code did `reserve(batch_size - capacity)`, but `Vec::reserve(additional)` guarantees `capacity >= len + additional` — not `capacity + additional`. When the internal message buffer had some leftover capacity but less than `batch_size`, the reservation fell short. The Steam API could then write messages beyond the allocated region, causing undefined behavior.

Since the buffer is always drained between calls (`len == 0`), passing `batch_size` directly gives the correct guarantee: `capacity >= batch_size`.

## Changes

Three call sites, same one-line fix each — replaced `reserve(batch_size - capacity)` with `reserve(batch_size)`.