### PR TITLE
Fix the compilation for `aarch64-unknown-linux-gnu`

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -153,8 +153,8 @@ impl Matchmaking {
 
     /// Returns the lobby metadata associated with the specified index
     pub fn lobby_data_by_index(&self, lobby: LobbyId, idx: u32) -> Option<(String, String)> {
-        let mut key = [0i8; sys::k_nMaxLobbyKeyLength as usize];
-        let mut value = [0i8; sys::k_cubChatMetadataMax as usize];
+        let mut key: [c_char; _] = [0; sys::k_nMaxLobbyKeyLength as usize];
+        let mut value: [c_char; _] = [0; sys::k_cubChatMetadataMax as usize];
         unsafe {
             let success = sys::SteamAPI_ISteamMatchmaking_GetLobbyDataByIndex(
                 self.mm,

--- a/src/matchmaking_servers.rs
+++ b/src/matchmaking_servers.rs
@@ -123,8 +123,8 @@ macro_rules! gen_server_list_fn {
                         return Err(());
                     }
 
-                    let mut key = [0i8; 256];
-                    let mut value = [0i8; 256];
+                    let mut key: [c_char; _] = [0; 256];
+                    let mut value: [c_char; _] = [0; 256];
 
                     unsafe {
                         key.as_mut_ptr()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -301,7 +301,7 @@ impl Utils {
     }
 }
 
-pub(crate) struct SteamParamStringArray(Vec<*mut i8>);
+pub(crate) struct SteamParamStringArray(Vec<*mut c_char>);
 impl Drop for SteamParamStringArray {
     fn drop(&mut self) {
         for c_string in &self.0 {


### PR DESCRIPTION
This library currently has compilation error when doing `cargo build --target aarch64-unknown-linux-gnu` because `c_char` is actually a `u8` on that platform rather than a `i8`.
This PR fixes this by using `c_char`  instead of `i8` when relevant.

(note: the reason why I would like to compile this library for `aarch64-unknown-linux-gnu` is simply because the GitHub larger runners for ARM are cheaper than the equivalent ones for x86)
