### PR TITLE
update DeleteItemResult to use optional SteamError instead of result

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -504,13 +504,16 @@ impl_callback!(cb: DownloadItemResult_t => DownloadItemResult {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DeleteItemResult {
     pub published_file_id: PublishedFileId,
-    pub result: sys::EResult,
+    pub error: Option<SteamError>,
 }
 
 impl_callback!(cb: DeleteItemResult_t => DeleteItemResult {
     Self {
         published_file_id: PublishedFileId(cb.m_nPublishedFileId),
-        result: cb.m_eResult,
+        error: match cb.m_eResult {
+            sys::EResult::k_EResultOK | sys::EResult::k_EResultNone => None,
+            error => Some(error.into()),
+        },
     }
 });
 


### PR DESCRIPTION
My bad, I fixed a crash with DeleteItem and I didnt do it properly last time