### PR TITLE
Fix DeleteItemResult breaking the serde feature

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -504,13 +504,16 @@ impl_callback!(cb: DownloadItemResult_t => DownloadItemResult {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DeleteItemResult {
     pub published_file_id: PublishedFileId,
-    pub result: sys::EResult,
+    pub error: Option<SteamError>,
 }
 
 impl_callback!(cb: DeleteItemResult_t => DeleteItemResult {
     Self {
         published_file_id: PublishedFileId(cb.m_nPublishedFileId),
-        result: cb.m_eResult,
+        error: match cb.m_eResult {
+            sys::EResult::k_EResultOK => None,
+            error => Some(error.into()),
+        },
     }
 });
 


### PR DESCRIPTION
## Problem

`DeleteItemResult` (added in #297 / f61961e) derives `Deserialize` behind the `serde` feature, but its `result: sys::EResult` field comes from `steamworks-sys` and does not implement `serde::Deserialize`. As a result, any downstream crate enabling `features = [\"serde\"]` fails to build:

```
error[E0277]: the trait bound `EResult: serde::Deserialize<'de>` is not satisfied
   --> src/ugc.rs:504:49
    |
504 | #[cfg_attr(feature = \"serde\", derive(Serialize, Deserialize))]
    |                                                 ^^^^^^^^^^^
```

This affects every rev from f61961e onward.

## Fix

Align `DeleteItemResult` with the existing `DownloadItemResult` pattern: expose the outcome as `Option<SteamError>` (`None` on `k_EResultOK`, `Some(err)` otherwise). `SteamError` already implements `Serialize`/`Deserialize`, so the `serde` feature compiles again, and the public API becomes consistent with the sibling callback.

Verified with `cargo check --features serde`.