### PR TITLE
Expose native library directory via links metadata

### DIFF
--- a/steamworks-sys/Cargo.toml
+++ b/steamworks-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "steamworks-sys"
 version = "0.12.0"
 authors = ["Thinkofname"]
 build = "build.rs"
+links = "steam_api"
 description = "Provides raw bindings to the steamworks sdk"
 license = "MIT / Apache-2.0"
 repository = "https://github.com/Noxime/steamworks-rs"

--- a/steamworks-sys/build.rs
+++ b/steamworks-sys/build.rs
@@ -58,6 +58,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rustc-link-search={}", out_path.display());
     println!("cargo:rustc-link-lib=dylib={}", lib);
 
+    // Expose the output directory so dependent crates can locate the shared
+    // library at build time (available as DEP_STEAM_API_LIB_DIR).
+    println!("cargo:lib_dir={}", out_path.display());
+
     #[cfg(feature = "rebuild-bindings")]
     {
         let target_os = if triple.contains("windows") {


### PR DESCRIPTION
## Problem

After building a binary that depends on `steamworks-sys`, running it fails:

```
error while loading shared libraries: libsteam_api.so: cannot open shared object file
```

The build script copies the shared library to `OUT_DIR` and sets `cargo:rustc-link-search`, which lets the linker find it at compile time. But the dynamic linker at runtime has no way to discover that path. Every consumer of this crate ends up working around this with `LD_LIBRARY_PATH`, fragile `find` commands that dig through cargo internals, or hardcoded `OUT_DIR` hashes that break on every rebuild.

## Changes

1. **`links = "steam_api"` in `steamworks-sys/Cargo.toml`**: the standard Cargo mechanism for native library crates to advertise metadata to consumers. Also prevents duplicate linking when multiple crates depend on steamworks-sys.

2. **`cargo:lib_dir` emission in `build.rs`**: makes `DEP_STEAM_API_LIB_DIR` available to any dependent crate's build script, pointing at the directory containing the shared library.

## How consumers use it

A binary crate that depends on steamworks can add a `build.rs` like:

```rust
fn main() {
    let lib_dir = std::env::var("DEP_STEAM_API_LIB_DIR").unwrap();
    // Copy libsteam_api.so next to the binary, set rpath, etc.
}
```

No more globbing through `~/.cargo/git/checkouts/` or `~/.cargo/registry/src/`.

Closes #316