### PR TITLE
Replace raw integers with existing corresponding rust types

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1154,14 +1154,14 @@ impl_callback!(cb: LobbyChatUpdate_t => LobbyChatUpdate {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LobbyCreated {
     /// The result of the operation (EResult). Possible values: k_EResultOK, k_EResultFail, k_EResultTimeout, k_EResultLimitExceeded, k_EResultAccessDenied, k_EResultNoConnection
-    pub result: u32,
+    pub result: SResult<()>,
     /// The Steam ID of the lobby that was created, 0 if failed.
     pub lobby: LobbyId,
 }
 
 impl_callback!(cb: LobbyCreated_t => LobbyCreated {
     Self {
-        result: cb.m_eResult as u32,
+        result: crate::to_steam_result(cb.m_eResult),
         lobby: LobbyId(cb.m_ulSteamIDLobby),
     }
 });

--- a/src/matchmaking_servers.rs
+++ b/src/matchmaking_servers.rs
@@ -171,7 +171,7 @@ macro_rules! gen_server_list_fn {
 }
 
 pub struct GameServerItem {
-    pub appid: u32,
+    pub appid: AppId,
     pub players: i32,
     pub do_not_refresh: bool,
     pub successful_response: bool,
@@ -181,7 +181,7 @@ pub struct GameServerItem {
     pub ping: Duration,
     pub max_players: i32,
     pub server_version: i32,
-    pub steamid: u64,
+    pub steamid: SteamId,
     pub last_time_played: Duration,
     pub addr: Ipv4Addr,
     pub query_port: u16,
@@ -197,13 +197,13 @@ impl GameServerItem {
     unsafe fn from_ptr(raw: *const sys::gameserveritem_t) -> Self {
         let raw = *raw;
         Self {
-            appid: raw.m_nAppID,
+            appid: AppId(raw.m_nAppID),
             players: raw.m_nPlayers,
             bot_players: raw.m_nBotPlayers,
             ping: Duration::from_millis(raw.m_nPing.try_into().unwrap()),
             max_players: raw.m_nMaxPlayers,
             server_version: raw.m_nServerVersion,
-            steamid: raw.m_steamID.m_steamid.m_unAll64Bits,
+            steamid: SteamId(raw.m_steamID.m_steamid.m_unAll64Bits),
 
             do_not_refresh: raw.m_bDoNotRefresh,
             successful_response: raw.m_bHadSuccessfulResponse,

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -246,12 +246,12 @@ impl_callback!(cb: P2PSessionRequest_t => P2PSessionRequest {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct P2PSessionConnectFail {
     pub remote: SteamId,
-    pub error: u8,
+    pub error: P2PSessionError,
 }
 
 impl_callback!(cb: P2PSessionConnectFail_t => P2PSessionConnectFail {
     Self {
         remote: SteamId(cb.m_steamIDRemote.m_steamid.m_unAll64Bits),
-        error: cb.m_eP2PSessionError,
+        error: P2PSessionError::from(cb.m_eP2PSessionError),
     }
 });


### PR DESCRIPTION
Hello again, with the new callbacks working properly, I've been using things like `LobbyCreated`, and found myself having to manipulate raw integers. 

So I thought i'd do a clean pass and add the types where it makes sense, using the steamworks documentation as a source of truth when necessary.

It's possible some of these were left un-typed for some reason, but they all seem reasonable to me.