### PR TITLE
Fix UserMakingChange SteamID to use correct value for LobbyChatUpdate

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1125,7 +1125,7 @@ impl_callback!(cb: LobbyChatUpdate_t => LobbyChatUpdate {
     Self {
         lobby: LobbyId(cb.m_ulSteamIDLobby),
         user_changed: SteamId(cb.m_ulSteamIDUserChanged),
-        making_change: SteamId(cb.m_ulSteamIDUserChanged),
+        making_change: SteamId(cb.m_ulSteamIDMakingChange),
         member_state_change: match cb.m_rgfChatMemberStateChange {
             x if x == sys::EChatMemberStateChange::k_EChatMemberStateChangeEntered as u32 => {
                 ChatMemberStateChange::Entered


### PR DESCRIPTION
We used the wrong user id for that struct field