### PR TITLE
Fix screenshot error mapping

### DIFF
--- a/src/screenshots.rs
+++ b/src/screenshots.rs
@@ -130,7 +130,7 @@ pub struct ScreenshotReady {
 impl_callback!(cb: ScreenshotReady_t => ScreenshotReady {
     let local_handle = match cb.m_eResult {
         sys::EResult::k_EResultOK => Ok(cb.m_hLocal),
-        sys::EResult::k_EResultIOFailure => Err(ScreenshotReadyError::Fail),
+        sys::EResult::k_EResultIOFailure => Err(ScreenshotReadyError::IoFailure),
         _ => Err(ScreenshotReadyError::Fail),
     };
 


### PR DESCRIPTION
Small fix on the screenshot ready error mapping.

The [documentation](https://partner.steamgames.com/doc/api/ISteamScreenshots#ScreenshotReady_t:~:text=k_EResultIOFailure%20%2D%20The%20screenshot%20could%20not%20be%20saved%20to%20the%20disk.) seems to indicate that it should be IoFailure (who is otherwise unused).