### PR TITLE
fix: handle EResult as a SResult instead of a Steam error that would panic if ok

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -385,13 +385,13 @@ impl_callback!(_cb: SteamServersConnected_t => SteamServersConnected {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamServersDisconnected {
-    /// The reason we were disconnected from the Steam servers
-    pub reason: SteamError,
+    /// The reason we were disconnected from the Steam servers.
+    pub reason: crate::SResult<()>,
 }
 
 impl_callback!(cb: SteamServersDisconnected_t => SteamServersDisconnected {
     Self {
-        reason: cb.m_eResult.into(),
+        reason: crate::to_steam_result(cb.m_eResult),
     }
 });
 
@@ -399,15 +399,15 @@ impl_callback!(cb: SteamServersDisconnected_t => SteamServersDisconnected {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamServerConnectFailure {
-    /// The reason we failed to connect to the Steam servers
-    pub reason: SteamError,
+    /// The reason we failed to connect to the Steam servers.
+    pub reason: crate::SResult<()>,
     /// Whether we are still retrying the connection.
     pub still_retrying: bool,
 }
 
 impl_callback!(cb: SteamServerConnectFailure_t => SteamServerConnectFailure {
     Self {
-        reason: cb.m_eResult.into(),
+        reason: crate::to_steam_result(cb.m_eResult),
         still_retrying: cb.m_bStillRetrying,
     }
 });


### PR DESCRIPTION
Despite their reason being `EResult`, [SteamServersDisconnected](https://partner.steamgames.com/doc/api/ISteamUser#SteamServersDisconnected_t) and [SteamServerConnectFailure](https://partner.steamgames.com/doc/api/ISteamUser#SteamServerConnectFailure_t), they were mapped to a `SteamError`, which panicked when converted from the raw number (see #327).

Instead, we map it to an `SResult`, which is what we already do to callbacks like [GetTicketForWebApiResponse](https://partner.steamgames.com/doc/api/ISteamUser#GetTicketForWebApiResponse_t)

Fixes #327 