### PR TITLE
fix: fix some callback handles being dropped

### DIFF
--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -105,9 +105,12 @@ impl NetworkingUtils {
         mut callback: impl FnMut(RelayNetworkStatus) + Send + 'static,
     ) {
         unsafe {
-            std::mem::forget(register_callback(&self.inner, move |status: RelayNetworkStatusCallback| {
-                callback(status.status);
-            }));
+            std::mem::forget(register_callback(
+                &self.inner,
+                move |status: RelayNetworkStatusCallback| {
+                    callback(status.status);
+                },
+            ));
         }
     }
 }

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -105,9 +105,9 @@ impl NetworkingUtils {
         mut callback: impl FnMut(RelayNetworkStatus) + Send + 'static,
     ) {
         unsafe {
-            register_callback(&self.inner, move |status: RelayNetworkStatusCallback| {
+            std::mem::forget(register_callback(&self.inner, move |status: RelayNetworkStatusCallback| {
                 callback(status.status);
-            });
+            }));
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -252,7 +252,7 @@ impl Utils {
         unsafe {
             let description = CString::new(description).unwrap();
             let existing_text = existing_text.map(|s| CString::new(s).unwrap());
-            register_callback(&self._inner, dismissed_cb);
+            std::mem::forget(register_callback(&self._inner, dismissed_cb));
             sys::SteamAPI_ISteamUtils_ShowGamepadTextInput(
                 self.utils,
                 input_mode.into(),
@@ -286,9 +286,9 @@ impl Utils {
         F: FnMut() + 'static + Send, // TODO: Support FnOnce callbacks
     {
         unsafe {
-            register_callback(&self._inner, move |_: FloatingGamepadTextInputDismissed| {
+            std::mem::forget(register_callback(&self._inner, move |_: FloatingGamepadTextInputDismissed| {
                 dismissed_cb();
-            });
+            }));
             sys::SteamAPI_ISteamUtils_ShowFloatingGamepadTextInput(
                 self.utils,
                 keyboard_mode.into(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -286,9 +286,12 @@ impl Utils {
         F: FnMut() + 'static + Send, // TODO: Support FnOnce callbacks
     {
         unsafe {
-            std::mem::forget(register_callback(&self._inner, move |_: FloatingGamepadTextInputDismissed| {
-                dismissed_cb();
-            }));
+            std::mem::forget(register_callback(
+                &self._inner,
+                move |_: FloatingGamepadTextInputDismissed| {
+                    dismissed_cb();
+                },
+            ));
             sys::SteamAPI_ISteamUtils_ShowFloatingGamepadTextInput(
                 self.utils,
                 keyboard_mode.into(),


### PR DESCRIPTION
The `register_callback` method returns a `CallbackHandle` which when drops, removes the callback registered at the id.

This means that the lifetime is critical, so some parts of the app store it in an `Arc` (for shared usage)  like `NetConnectionStatusChangedCallback`, while most others just `std::mem::forget` since the registration is a one time thing.

I personally think that it's a bit weird, but since it's the simpler implementation of the two, it is what I did to the `register_callbacks` that were dropped (`FloatingGamepadTextInputDismissed`, `GamepadTextInputDismissed` and `RelayNetworkStatusCallback`).

Perhaps future work could make that problem harder to run into or standardize the solution.

Fixes #328 