### PR TITLE
fix: Don't panic internally in SteamError conversion.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -157,7 +157,7 @@ impl Apps {
         }
     }
 
-    /// Gets the associated launch parameter if the game is run via steam://run/<appid>/?param1=value1;param2=value2;param3=value3 etc.
+    /// Gets the associated launch parameter if the game is run via `steam://run/<appid>/?param1=value1;param2=value2;param3=value3` etc.
     ///
     /// Parameter names starting with the character '@' are reserved for internal use and will always return an empty string.
     /// Parameter names starting with an underscore '_' are reserved for steam features -- they can be queried by the game, but it is advised that you don't use param names beginning with an underscore for your own features.
@@ -173,7 +173,7 @@ impl Apps {
     }
 }
 
-/// Called after the user executes a steam url with command line or query parameters such as steam://run/<appid>//?param1=value1;param2=value2;param3=value3; while the game is already running.
+/// Called after the user executes a steam url with command line or query parameters such as `steam://run/<appid>/?param1=value1;param2=value2;param3=value3` while the game is already running.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NewUrlLaunchParameters;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,16 +4,94 @@ use serde::{Deserialize, Serialize};
 use crate::sys;
 use std::{convert::TryFrom, ffi::CStr};
 
-/// Covers errors that can be returned by the steamworks API
-///
-/// Documentation is based on official documentation which doesn't
-/// always explain when an error could be returned or its meaning.
-#[derive(Copy, Clone, Debug, Error, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SteamError {
-    /// Returned if the steamworks API fails to initialize.
-    #[error("failed to init the steamworks API")]
-    InitFailed,
+/// Link to a page/id on the official Steamworks API Reference. For doc comments
+macro_rules! docs_link {
+    ($page:ident/$id:ident) => {
+        concat!(
+            "_Steamworks API Reference:_ [`",
+            stringify!($id),
+            "`](https://partner.steamgames.com/doc/api/",
+            stringify!($page),
+            "#",
+            stringify!($id),
+            ")"
+        )
+    };
+}
+
+/// Map a SteamError name to its raw binding name. Most are direct mappings, but some aren't.
+macro_rules! map_binding_name {
+    (Generic) => {
+        k_EResultFail
+    };
+    (InvalidProtocolVersion) => {
+        k_EResultInvalidProtocolVer
+    };
+    (InvalidParameter) => {
+        k_EResultInvalidParam
+    };
+    ($variant:ident) => {
+        paste::paste! { [< k_EResult $variant >] }
+    };
+}
+
+/// Implementation of SteamError. Macro is a little bit harder to read but avoids us accidentally missing a variant match
+macro_rules! steam_error {
+    (
+        $(
+            $(
+                #[doc = $doc:expr] // doc comment gets expanded before macro exp, so we match it like this
+            )*
+            #[error($error:expr)]
+            $variant:ident
+        ),*
+    ) => {
+        paste::paste! {
+            /// Covers errors that can be returned by the steamworks API
+            ///
+            /// Note that all [`EResult`](sys::EResult) values are [`SteamError`]s, as for example
+            /// [`k_EResultOK`](sys::EResult::k_EResultOK) is not an error at all.
+            ///
+            /// Documentation is based on official documentation which doesn't
+            /// always explain when an error could be returned or its meaning.
+            #[derive(Copy, Clone, Debug, Error, PartialEq, Eq)]
+            #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+            pub enum SteamError {
+                $(
+                    // Link to official doc, then doc comments
+                    #[doc = concat!("**\"", $error, "\"** (", docs_link!(steam_api/[<k_EResult $variant>]), ")\n\n")]
+                    $(
+                        #[doc = $doc]
+                    )*
+                    #[error($error)]
+                    $variant
+                ),*
+            }
+        }
+
+
+            impl TryFrom<i64> for SteamError {
+                type Error = InvalidSteamError;
+                fn try_from(raw: i64) -> Result<Self, Self::Error> {
+                    use sys::EResult::*;
+                    let ok = match raw {
+                        x if x == sys::EResult::k_EResultOK as i64 => return Err(InvalidSteamError::Ok),
+
+                        $(
+                            x if x == map_binding_name!($variant) as i64 => SteamError::$variant,
+                        )*
+
+                        // Unhandled error, either something undocumented or a new error.
+                        _ => return Err(InvalidSteamError::Unknown(raw)),
+                    };
+
+                    Ok(ok)
+                }
+            }
+    };
+}
+
+steam_error! {
     /// Returned if the steamworks API fails to perform an action
     #[error("a generic failure from the steamworks API")]
     Generic,
@@ -423,423 +501,41 @@ pub enum SteamError {
     #[error("The local data for the offline mode cache is insufficient to login")]
     OfflineAppCacheInvalid,
     #[error("retry the operation later")]
-    TryLater,
+    TryLater
 }
 
-impl From<sys::EResult> for SteamError {
-    fn from(r: sys::EResult) -> Self {
-        match r {
-            sys::EResult::k_EResultOK => panic!("EResult::k_EResultOK isn't an error"),
-            sys::EResult::k_EResultFail => SteamError::Generic,
-            sys::EResult::k_EResultNoConnection => SteamError::NoConnection,
-            sys::EResult::k_EResultInvalidPassword => SteamError::InvalidPassword,
-            sys::EResult::k_EResultLoggedInElsewhere => SteamError::LoggedInElsewhere,
-            sys::EResult::k_EResultInvalidProtocolVer => SteamError::InvalidProtocolVersion,
-            sys::EResult::k_EResultInvalidParam => SteamError::InvalidParameter,
-            sys::EResult::k_EResultFileNotFound => SteamError::FileNotFound,
-            sys::EResult::k_EResultBusy => SteamError::Busy,
-            sys::EResult::k_EResultInvalidState => SteamError::InvalidState,
-            sys::EResult::k_EResultInvalidName => SteamError::InvalidName,
-            sys::EResult::k_EResultInvalidEmail => SteamError::InvalidEmail,
-            sys::EResult::k_EResultDuplicateName => SteamError::DuplicateName,
-            sys::EResult::k_EResultAccessDenied => SteamError::AccessDenied,
-            sys::EResult::k_EResultTimeout => SteamError::Timeout,
-            sys::EResult::k_EResultBanned => SteamError::Banned,
-            sys::EResult::k_EResultAccountNotFound => SteamError::AccountNotFound,
-            sys::EResult::k_EResultInvalidSteamID => SteamError::InvalidSteamID,
-            sys::EResult::k_EResultServiceUnavailable => SteamError::ServiceUnavailable,
-            sys::EResult::k_EResultNotLoggedOn => SteamError::NotLoggedOn,
-            sys::EResult::k_EResultPending => SteamError::Pending,
-            sys::EResult::k_EResultEncryptionFailure => SteamError::EncryptionFailure,
-            sys::EResult::k_EResultInsufficientPrivilege => SteamError::InsufficientPrivilege,
-            sys::EResult::k_EResultLimitExceeded => SteamError::LimitExceeded,
-            sys::EResult::k_EResultRevoked => SteamError::Revoked,
-            sys::EResult::k_EResultExpired => SteamError::Expired,
-            sys::EResult::k_EResultAlreadyRedeemed => SteamError::AlreadyRedeemed,
-            sys::EResult::k_EResultDuplicateRequest => SteamError::DuplicateRequest,
-            sys::EResult::k_EResultAlreadyOwned => SteamError::AlreadyOwned,
-            sys::EResult::k_EResultIPNotFound => SteamError::IPNotFound,
-            sys::EResult::k_EResultPersistFailed => SteamError::PersistFailed,
-            sys::EResult::k_EResultLockingFailed => SteamError::LockingFailed,
-            sys::EResult::k_EResultLogonSessionReplaced => SteamError::LogonSessionReplaced,
-            sys::EResult::k_EResultConnectFailed => SteamError::ConnectFailed,
-            sys::EResult::k_EResultHandshakeFailed => SteamError::HandshakeFailed,
-            sys::EResult::k_EResultIOFailure => SteamError::IOFailure,
-            sys::EResult::k_EResultRemoteDisconnect => SteamError::RemoteDisconnect,
-            sys::EResult::k_EResultShoppingCartNotFound => SteamError::ShoppingCartNotFound,
-            sys::EResult::k_EResultBlocked => SteamError::Blocked,
-            sys::EResult::k_EResultIgnored => SteamError::Ignored,
-            sys::EResult::k_EResultNoMatch => SteamError::NoMatch,
-            sys::EResult::k_EResultAccountDisabled => SteamError::AccountDisabled,
-            sys::EResult::k_EResultServiceReadOnly => SteamError::ServiceReadOnly,
-            sys::EResult::k_EResultAccountNotFeatured => SteamError::AccountNotFeatured,
-            sys::EResult::k_EResultAdministratorOK => SteamError::AdministratorOK,
-            sys::EResult::k_EResultContentVersion => SteamError::ContentVersion,
-            sys::EResult::k_EResultTryAnotherCM => SteamError::TryAnotherCM,
-            sys::EResult::k_EResultPasswordRequiredToKickSession => {
-                SteamError::PasswordRequiredToKickSession
-            }
-            sys::EResult::k_EResultAlreadyLoggedInElsewhere => SteamError::AlreadyLoggedInElsewhere,
-            sys::EResult::k_EResultSuspended => SteamError::Suspended,
-            sys::EResult::k_EResultCancelled => SteamError::Cancelled,
-            sys::EResult::k_EResultDataCorruption => SteamError::DataCorruption,
-            sys::EResult::k_EResultDiskFull => SteamError::DiskFull,
-            sys::EResult::k_EResultRemoteCallFailed => SteamError::RemoteCallFailed,
-            sys::EResult::k_EResultPasswordUnset => SteamError::PasswordUnset,
-            sys::EResult::k_EResultExternalAccountUnlinked => SteamError::ExternalAccountUnlinked,
-            sys::EResult::k_EResultPSNTicketInvalid => SteamError::PSNTicketInvalid,
-            sys::EResult::k_EResultExternalAccountAlreadyLinked => {
-                SteamError::ExternalAccountAlreadyLinked
-            }
-            sys::EResult::k_EResultRemoteFileConflict => SteamError::RemoteFileConflict,
-            sys::EResult::k_EResultIllegalPassword => SteamError::IllegalPassword,
-            sys::EResult::k_EResultSameAsPreviousValue => SteamError::SameAsPreviousValue,
-            sys::EResult::k_EResultAccountLogonDenied => SteamError::AccountLogonDenied,
-            sys::EResult::k_EResultCannotUseOldPassword => SteamError::CannotUseOldPassword,
-            sys::EResult::k_EResultInvalidLoginAuthCode => SteamError::InvalidLoginAuthCode,
-            sys::EResult::k_EResultAccountLogonDeniedNoMail => SteamError::AccountLogonDeniedNoMail,
-            sys::EResult::k_EResultHardwareNotCapableOfIPT => SteamError::HardwareNotCapableOfIPT,
-            sys::EResult::k_EResultIPTInitError => SteamError::IPTInitError,
-            sys::EResult::k_EResultParentalControlRestricted => {
-                SteamError::ParentalControlRestricted
-            }
-            sys::EResult::k_EResultFacebookQueryError => SteamError::FacebookQueryError,
-            sys::EResult::k_EResultExpiredLoginAuthCode => SteamError::ExpiredLoginAuthCode,
-            sys::EResult::k_EResultIPLoginRestrictionFailed => SteamError::IPLoginRestrictionFailed,
-            sys::EResult::k_EResultAccountLockedDown => SteamError::AccountLockedDown,
-            sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired => {
-                SteamError::AccountLogonDeniedVerifiedEmailRequired
-            }
-            sys::EResult::k_EResultNoMatchingURL => SteamError::NoMatchingURL,
-            sys::EResult::k_EResultBadResponse => SteamError::BadResponse,
-            sys::EResult::k_EResultRequirePasswordReEntry => SteamError::RequirePasswordReEntry,
-            sys::EResult::k_EResultValueOutOfRange => SteamError::ValueOutOfRange,
-            sys::EResult::k_EResultUnexpectedError => SteamError::UnexpectedError,
-            sys::EResult::k_EResultDisabled => SteamError::Disabled,
-            sys::EResult::k_EResultInvalidCEGSubmission => SteamError::InvalidCEGSubmission,
-            sys::EResult::k_EResultRestrictedDevice => SteamError::RestrictedDevice,
-            sys::EResult::k_EResultRegionLocked => SteamError::RegionLocked,
-            sys::EResult::k_EResultRateLimitExceeded => SteamError::RateLimitExceeded,
-            sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor => {
-                SteamError::AccountLoginDeniedNeedTwoFactor
-            }
-            sys::EResult::k_EResultItemDeleted => SteamError::ItemDeleted,
-            sys::EResult::k_EResultAccountLoginDeniedThrottle => {
-                SteamError::AccountLoginDeniedThrottle
-            }
-            sys::EResult::k_EResultTwoFactorCodeMismatch => SteamError::TwoFactorCodeMismatch,
-            sys::EResult::k_EResultTwoFactorActivationCodeMismatch => {
-                SteamError::TwoFactorActivationCodeMismatch
-            }
-            sys::EResult::k_EResultAccountAssociatedToMultiplePartners => {
-                SteamError::AccountAssociatedToMultiplePartners
-            }
-            sys::EResult::k_EResultNotModified => SteamError::NotModified,
-            sys::EResult::k_EResultNoMobileDevice => SteamError::NoMobileDevice,
-            sys::EResult::k_EResultTimeNotSynced => SteamError::TimeNotSynced,
-            sys::EResult::k_EResultSmsCodeFailed => SteamError::SmsCodeFailed,
-            sys::EResult::k_EResultAccountLimitExceeded => SteamError::AccountLimitExceeded,
-            sys::EResult::k_EResultAccountActivityLimitExceeded => {
-                SteamError::AccountActivityLimitExceeded
-            }
-            sys::EResult::k_EResultPhoneActivityLimitExceeded => {
-                SteamError::PhoneActivityLimitExceeded
-            }
-            sys::EResult::k_EResultRefundToWallet => SteamError::RefundToWallet,
-            sys::EResult::k_EResultEmailSendFailure => SteamError::EmailSendFailure,
-            sys::EResult::k_EResultNotSettled => SteamError::NotSettled,
-            sys::EResult::k_EResultNeedCaptcha => SteamError::NeedCaptcha,
-            sys::EResult::k_EResultGSLTDenied => SteamError::GSLTDenied,
-            sys::EResult::k_EResultGSOwnerDenied => SteamError::GSOwnerDenied,
-            sys::EResult::k_EResultInvalidItemType => SteamError::InvalidItemType,
-            sys::EResult::k_EResultIPBanned => SteamError::IPBanned,
-            sys::EResult::k_EResultGSLTExpired => SteamError::GSLTExpired,
-            sys::EResult::k_EResultInsufficientFunds => SteamError::InsufficientFunds,
-            sys::EResult::k_EResultTooManyPending => SteamError::TooManyPending,
-            sys::EResult::k_EResultNoSiteLicensesFound => SteamError::NoSiteLicensesFound,
-            sys::EResult::k_EResultWGNetworkSendExceeded => SteamError::WGNetworkSendExceeded,
-            sys::EResult::k_EResultAccountNotFriends => SteamError::AccountNotFriends,
-            sys::EResult::k_EResultLimitedUserAccount => SteamError::LimitedUserAccount,
-            sys::EResult::k_EResultCantRemoveItem => SteamError::CantRemoveItem,
-            sys::EResult::k_EResultAccountDeleted => SteamError::AccountDeleted,
-            sys::EResult::k_EResultExistingUserCancelledLicense => {
-                SteamError::ExistingUserCancelledLicense
-            }
-            sys::EResult::k_EResultCommunityCooldown => SteamError::CommunityCooldown,
-            sys::EResult::k_EResultNoLauncherSpecified => SteamError::NoLauncherSpecified,
-            sys::EResult::k_EResultMustAgreeToSSA => SteamError::MustAgreeToSSA,
-            sys::EResult::k_EResultLauncherMigrated => SteamError::LauncherMigrated,
-            sys::EResult::k_EResultSteamRealmMismatch => SteamError::SteamRealmMismatch,
-            sys::EResult::k_EResultInvalidSignature => SteamError::InvalidSignature,
-            sys::EResult::k_EResultParseFailure => SteamError::ParseFailure,
-            sys::EResult::k_EResultNoVerifiedPhone => SteamError::NoVerifiedPhone,
-            sys::EResult::k_EResultInsufficientBattery => SteamError::InsufficientBattery,
-            sys::EResult::k_EResultChargerRequired => SteamError::ChargerRequired,
-            sys::EResult::k_EResultCachedCredentialInvalid => SteamError::CachedCredentialInvalid,
-            sys::EResult::k_EResultNotSupported => SteamError::NotSupported,
-            sys::EResult::k_EResultFamilySizeLimitExceeded => SteamError::FamilySizeLimitExceeded,
-            sys::EResult::k_EResultOfflineAppCacheInvalid => SteamError::OfflineAppCacheInvalid,
-            sys::EResult::k_EResultTryLater => SteamError::TryLater,
-            _ => unreachable!(),
-        }
+// There is no Try<EResult>
+impl TryFrom<sys::EResult> for SteamError {
+    type Error = InvalidSteamError;
+    fn try_from(raw: sys::EResult) -> Result<Self, Self::Error> {
+        Self::try_from(raw as i64)
     }
 }
 
-impl TryFrom<i64> for SteamError {
-    type Error = InvalidErrorCode;
-
-    fn try_from(r: i64) -> Result<Self, Self::Error> {
-        let error = match r {
-            x if x == sys::EResult::k_EResultFail as i64 => SteamError::Generic,
-            x if x == sys::EResult::k_EResultNoConnection as i64 => SteamError::NoConnection,
-            x if x == sys::EResult::k_EResultInvalidPassword as i64 => SteamError::InvalidPassword,
-            x if x == sys::EResult::k_EResultLoggedInElsewhere as i64 => {
-                SteamError::LoggedInElsewhere
-            }
-            x if x == sys::EResult::k_EResultInvalidProtocolVer as i64 => {
-                SteamError::InvalidProtocolVersion
-            }
-            x if x == sys::EResult::k_EResultInvalidParam as i64 => SteamError::InvalidParameter,
-            x if x == sys::EResult::k_EResultFileNotFound as i64 => SteamError::FileNotFound,
-            x if x == sys::EResult::k_EResultBusy as i64 => SteamError::Busy,
-            x if x == sys::EResult::k_EResultInvalidState as i64 => SteamError::InvalidState,
-            x if x == sys::EResult::k_EResultInvalidName as i64 => SteamError::InvalidName,
-            x if x == sys::EResult::k_EResultInvalidEmail as i64 => SteamError::InvalidEmail,
-            x if x == sys::EResult::k_EResultDuplicateName as i64 => SteamError::DuplicateName,
-            x if x == sys::EResult::k_EResultAccessDenied as i64 => SteamError::AccessDenied,
-            x if x == sys::EResult::k_EResultTimeout as i64 => SteamError::Timeout,
-            x if x == sys::EResult::k_EResultBanned as i64 => SteamError::Banned,
-            x if x == sys::EResult::k_EResultAccountNotFound as i64 => SteamError::AccountNotFound,
-            x if x == sys::EResult::k_EResultInvalidSteamID as i64 => SteamError::InvalidSteamID,
-            x if x == sys::EResult::k_EResultServiceUnavailable as i64 => {
-                SteamError::ServiceUnavailable
-            }
-            x if x == sys::EResult::k_EResultNotLoggedOn as i64 => SteamError::NotLoggedOn,
-            x if x == sys::EResult::k_EResultPending as i64 => SteamError::Pending,
-            x if x == sys::EResult::k_EResultEncryptionFailure as i64 => {
-                SteamError::EncryptionFailure
-            }
-            x if x == sys::EResult::k_EResultInsufficientPrivilege as i64 => {
-                SteamError::InsufficientPrivilege
-            }
-            x if x == sys::EResult::k_EResultLimitExceeded as i64 => SteamError::LimitExceeded,
-            x if x == sys::EResult::k_EResultRevoked as i64 => SteamError::Revoked,
-            x if x == sys::EResult::k_EResultExpired as i64 => SteamError::Expired,
-            x if x == sys::EResult::k_EResultAlreadyRedeemed as i64 => SteamError::AlreadyRedeemed,
-            x if x == sys::EResult::k_EResultDuplicateRequest as i64 => {
-                SteamError::DuplicateRequest
-            }
-            x if x == sys::EResult::k_EResultAlreadyOwned as i64 => SteamError::AlreadyOwned,
-            x if x == sys::EResult::k_EResultIPNotFound as i64 => SteamError::IPNotFound,
-            x if x == sys::EResult::k_EResultPersistFailed as i64 => SteamError::PersistFailed,
-            x if x == sys::EResult::k_EResultLockingFailed as i64 => SteamError::LockingFailed,
-            x if x == sys::EResult::k_EResultLogonSessionReplaced as i64 => {
-                SteamError::LogonSessionReplaced
-            }
-            x if x == sys::EResult::k_EResultConnectFailed as i64 => SteamError::ConnectFailed,
-            x if x == sys::EResult::k_EResultHandshakeFailed as i64 => SteamError::HandshakeFailed,
-            x if x == sys::EResult::k_EResultIOFailure as i64 => SteamError::IOFailure,
-            x if x == sys::EResult::k_EResultRemoteDisconnect as i64 => {
-                SteamError::RemoteDisconnect
-            }
-            x if x == sys::EResult::k_EResultShoppingCartNotFound as i64 => {
-                SteamError::ShoppingCartNotFound
-            }
-            x if x == sys::EResult::k_EResultBlocked as i64 => SteamError::Blocked,
-            x if x == sys::EResult::k_EResultIgnored as i64 => SteamError::Ignored,
-            x if x == sys::EResult::k_EResultNoMatch as i64 => SteamError::NoMatch,
-            x if x == sys::EResult::k_EResultAccountDisabled as i64 => SteamError::AccountDisabled,
-            x if x == sys::EResult::k_EResultServiceReadOnly as i64 => SteamError::ServiceReadOnly,
-            x if x == sys::EResult::k_EResultAccountNotFeatured as i64 => {
-                SteamError::AccountNotFeatured
-            }
-            x if x == sys::EResult::k_EResultAdministratorOK as i64 => SteamError::AdministratorOK,
-            x if x == sys::EResult::k_EResultContentVersion as i64 => SteamError::ContentVersion,
-            x if x == sys::EResult::k_EResultTryAnotherCM as i64 => SteamError::TryAnotherCM,
-            x if x == sys::EResult::k_EResultPasswordRequiredToKickSession as i64 => {
-                SteamError::PasswordRequiredToKickSession
-            }
-            x if x == sys::EResult::k_EResultAlreadyLoggedInElsewhere as i64 => {
-                SteamError::AlreadyLoggedInElsewhere
-            }
-            x if x == sys::EResult::k_EResultSuspended as i64 => SteamError::Suspended,
-            x if x == sys::EResult::k_EResultCancelled as i64 => SteamError::Cancelled,
-            x if x == sys::EResult::k_EResultDataCorruption as i64 => SteamError::DataCorruption,
-            x if x == sys::EResult::k_EResultDiskFull as i64 => SteamError::DiskFull,
-            x if x == sys::EResult::k_EResultRemoteCallFailed as i64 => {
-                SteamError::RemoteCallFailed
-            }
-            x if x == sys::EResult::k_EResultPasswordUnset as i64 => SteamError::PasswordUnset,
-            x if x == sys::EResult::k_EResultExternalAccountUnlinked as i64 => {
-                SteamError::ExternalAccountUnlinked
-            }
-            x if x == sys::EResult::k_EResultPSNTicketInvalid as i64 => {
-                SteamError::PSNTicketInvalid
-            }
-            x if x == sys::EResult::k_EResultExternalAccountAlreadyLinked as i64 => {
-                SteamError::ExternalAccountAlreadyLinked
-            }
-            x if x == sys::EResult::k_EResultRemoteFileConflict as i64 => {
-                SteamError::RemoteFileConflict
-            }
-            x if x == sys::EResult::k_EResultIllegalPassword as i64 => SteamError::IllegalPassword,
-            x if x == sys::EResult::k_EResultSameAsPreviousValue as i64 => {
-                SteamError::SameAsPreviousValue
-            }
-            x if x == sys::EResult::k_EResultAccountLogonDenied as i64 => {
-                SteamError::AccountLogonDenied
-            }
-            x if x == sys::EResult::k_EResultCannotUseOldPassword as i64 => {
-                SteamError::CannotUseOldPassword
-            }
-            x if x == sys::EResult::k_EResultInvalidLoginAuthCode as i64 => {
-                SteamError::InvalidLoginAuthCode
-            }
-            x if x == sys::EResult::k_EResultAccountLogonDeniedNoMail as i64 => {
-                SteamError::AccountLogonDeniedNoMail
-            }
-            x if x == sys::EResult::k_EResultHardwareNotCapableOfIPT as i64 => {
-                SteamError::HardwareNotCapableOfIPT
-            }
-            x if x == sys::EResult::k_EResultIPTInitError as i64 => SteamError::IPTInitError,
-            x if x == sys::EResult::k_EResultParentalControlRestricted as i64 => {
-                SteamError::ParentalControlRestricted
-            }
-            x if x == sys::EResult::k_EResultFacebookQueryError as i64 => {
-                SteamError::FacebookQueryError
-            }
-            x if x == sys::EResult::k_EResultExpiredLoginAuthCode as i64 => {
-                SteamError::ExpiredLoginAuthCode
-            }
-            x if x == sys::EResult::k_EResultIPLoginRestrictionFailed as i64 => {
-                SteamError::IPLoginRestrictionFailed
-            }
-            x if x == sys::EResult::k_EResultAccountLockedDown as i64 => {
-                SteamError::AccountLockedDown
-            }
-            x if x == sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired as i64 => {
-                SteamError::AccountLogonDeniedVerifiedEmailRequired
-            }
-            x if x == sys::EResult::k_EResultNoMatchingURL as i64 => SteamError::NoMatchingURL,
-            x if x == sys::EResult::k_EResultBadResponse as i64 => SteamError::BadResponse,
-            x if x == sys::EResult::k_EResultRequirePasswordReEntry as i64 => {
-                SteamError::RequirePasswordReEntry
-            }
-            x if x == sys::EResult::k_EResultValueOutOfRange as i64 => SteamError::ValueOutOfRange,
-            x if x == sys::EResult::k_EResultUnexpectedError as i64 => SteamError::UnexpectedError,
-            x if x == sys::EResult::k_EResultDisabled as i64 => SteamError::Disabled,
-            x if x == sys::EResult::k_EResultInvalidCEGSubmission as i64 => {
-                SteamError::InvalidCEGSubmission
-            }
-            x if x == sys::EResult::k_EResultRestrictedDevice as i64 => {
-                SteamError::RestrictedDevice
-            }
-            x if x == sys::EResult::k_EResultRegionLocked as i64 => SteamError::RegionLocked,
-            x if x == sys::EResult::k_EResultRateLimitExceeded as i64 => {
-                SteamError::RateLimitExceeded
-            }
-            x if x == sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor as i64 => {
-                SteamError::AccountLoginDeniedNeedTwoFactor
-            }
-            x if x == sys::EResult::k_EResultItemDeleted as i64 => SteamError::ItemDeleted,
-            x if x == sys::EResult::k_EResultAccountLoginDeniedThrottle as i64 => {
-                SteamError::AccountLoginDeniedThrottle
-            }
-            x if x == sys::EResult::k_EResultTwoFactorCodeMismatch as i64 => {
-                SteamError::TwoFactorCodeMismatch
-            }
-            x if x == sys::EResult::k_EResultTwoFactorActivationCodeMismatch as i64 => {
-                SteamError::TwoFactorActivationCodeMismatch
-            }
-            x if x == sys::EResult::k_EResultAccountAssociatedToMultiplePartners as i64 => {
-                SteamError::AccountAssociatedToMultiplePartners
-            }
-            x if x == sys::EResult::k_EResultNotModified as i64 => SteamError::NotModified,
-            x if x == sys::EResult::k_EResultNoMobileDevice as i64 => SteamError::NoMobileDevice,
-            x if x == sys::EResult::k_EResultTimeNotSynced as i64 => SteamError::TimeNotSynced,
-            x if x == sys::EResult::k_EResultSmsCodeFailed as i64 => SteamError::SmsCodeFailed,
-            x if x == sys::EResult::k_EResultAccountLimitExceeded as i64 => {
-                SteamError::AccountLimitExceeded
-            }
-            x if x == sys::EResult::k_EResultAccountActivityLimitExceeded as i64 => {
-                SteamError::AccountActivityLimitExceeded
-            }
-            x if x == sys::EResult::k_EResultPhoneActivityLimitExceeded as i64 => {
-                SteamError::PhoneActivityLimitExceeded
-            }
-            x if x == sys::EResult::k_EResultRefundToWallet as i64 => SteamError::RefundToWallet,
-            x if x == sys::EResult::k_EResultEmailSendFailure as i64 => {
-                SteamError::EmailSendFailure
-            }
-            x if x == sys::EResult::k_EResultNotSettled as i64 => SteamError::NotSettled,
-            x if x == sys::EResult::k_EResultNeedCaptcha as i64 => SteamError::NeedCaptcha,
-            x if x == sys::EResult::k_EResultGSLTDenied as i64 => SteamError::GSLTDenied,
-            x if x == sys::EResult::k_EResultGSOwnerDenied as i64 => SteamError::GSOwnerDenied,
-            x if x == sys::EResult::k_EResultInvalidItemType as i64 => SteamError::InvalidItemType,
-            x if x == sys::EResult::k_EResultIPBanned as i64 => SteamError::IPBanned,
-            x if x == sys::EResult::k_EResultGSLTExpired as i64 => SteamError::GSLTExpired,
-            x if x == sys::EResult::k_EResultInsufficientFunds as i64 => {
-                SteamError::InsufficientFunds
-            }
-            x if x == sys::EResult::k_EResultTooManyPending as i64 => SteamError::TooManyPending,
-            x if x == sys::EResult::k_EResultNoSiteLicensesFound as i64 => {
-                SteamError::NoSiteLicensesFound
-            }
-            x if x == sys::EResult::k_EResultWGNetworkSendExceeded as i64 => {
-                SteamError::WGNetworkSendExceeded
-            }
-            x if x == sys::EResult::k_EResultCommunityCooldown as i64 => {
-                SteamError::CommunityCooldown
-            }
-            x if x == sys::EResult::k_EResultNoLauncherSpecified as i64 => {
-                SteamError::NoLauncherSpecified
-            }
-            x if x == sys::EResult::k_EResultMustAgreeToSSA as i64 => SteamError::MustAgreeToSSA,
-            x if x == sys::EResult::k_EResultLauncherMigrated as i64 => {
-                SteamError::LauncherMigrated
-            }
-            x if x == sys::EResult::k_EResultSteamRealmMismatch as i64 => {
-                SteamError::SteamRealmMismatch
-            }
-            x if x == sys::EResult::k_EResultInvalidSignature as i64 => {
-                SteamError::InvalidSignature
-            }
-            x if x == sys::EResult::k_EResultParseFailure as i64 => SteamError::ParseFailure,
-            x if x == sys::EResult::k_EResultNoVerifiedPhone as i64 => SteamError::NoVerifiedPhone,
-            x if x == sys::EResult::k_EResultInsufficientBattery as i64 => {
-                SteamError::InsufficientBattery
-            }
-            x if x == sys::EResult::k_EResultChargerRequired as i64 => SteamError::ChargerRequired,
-            x if x == sys::EResult::k_EResultCachedCredentialInvalid as i64 => {
-                SteamError::CachedCredentialInvalid
-            }
-            x if x == sys::EResult::k_EResultNotSupported as i64 => SteamError::NotSupported,
-            x if x == sys::EResult::k_EResultFamilySizeLimitExceeded as i64 => {
-                SteamError::FamilySizeLimitExceeded
-            }
-            x if x == sys::EResult::k_EResultOfflineAppCacheInvalid as i64 => {
-                SteamError::OfflineAppCacheInvalid
-            }
-            x if x == sys::EResult::k_EResultTryLater as i64 => SteamError::TryLater,
-            _ => return Err(InvalidErrorCode),
-        };
-        Ok(error)
-    }
-}
-
+/// Unrecognized error code, or code that isn't an error ([`sys::EResult::k_EResultOK`])
 #[derive(Debug, Error)]
-#[error("error code could not be converted to rust enum")]
-pub struct InvalidErrorCode;
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum InvalidSteamError {
+    /// Error wasn't an error after all, but Ok
+    #[error("error is 'ok'")]
+    Ok,
+    /// Error code was not recognized as a valid error code by steamworks-rs
+    #[error("error code {0} could not be converted to enum")]
+    Unknown(i64),
+}
 
+/// Error returned in API initialization.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum SteamAPIInitError {
     #[error("Some other failure")]
-    FailedGeneric(String),
+    Generic(String),
 
+    /// Returned when we can't connect to steam, probably because it's not running.
     #[error("We cannot connect to Steam, steam probably isn't running")]
     NoSteamClient(String),
 
+    /// Returned when the version of the steam client is too old to work with this version of the API.
     #[error("Steam client appears to be out of date")]
     VersionMismatch(String),
 }
@@ -856,7 +552,7 @@ impl SteamAPIInitError {
 
         match result {
             sys::ESteamAPIInitResult::k_ESteamAPIInitResult_FailedGeneric => {
-                SteamAPIInitError::FailedGeneric(err_string)
+                SteamAPIInitError::Generic(err_string)
             }
             sys::ESteamAPIInitResult::k_ESteamAPIInitResult_NoSteamClient => {
                 SteamAPIInitError::NoSteamClient(err_string)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,15 +63,15 @@ mod user;
 mod user_stats;
 mod utils;
 
-pub type SResult<T> = Result<T, SteamError>;
+/// Alias for [`Result<T, SteamError>`](SteamError)
+pub type SteamResult<T = ()> = Result<T, SteamError>;
 
-pub type SIResult<T> = Result<T, SteamAPIInitError>;
-
-pub(crate) fn to_steam_result(result: sys::EResult) -> SResult<()> {
-    if result == sys::EResult::k_EResultOK {
-        Ok(())
-    } else {
-        Err(result.into())
+/// Convert a raw result to a Rust [`Result`] type.
+pub(crate) fn to_steam_result(result: sys::EResult) -> SteamResult {
+    match result {
+        // sys::EResult::k_EResultNone => Ok(()), TODO: I'm not sure if this is considered a success
+        sys::EResult::k_EResultOK => Ok(()),
+        error => Err(error.try_into().unwrap()),
     }
 }
 
@@ -116,7 +116,7 @@ impl Inner {
     /// thread.
     ///
     /// This should be called frequently (e.g. once per a frame)
-    /// in order to reduce the latency between recieving events.
+    /// in order to reduce the latency between receiving events.
     pub fn run_callbacks(&self) {
         self.run_callbacks_raw(|cb_discrim, data| {
             let mut callbacks = self.callbacks.callbacks.lock().unwrap();
@@ -132,10 +132,10 @@ impl Inner {
     /// `callback_handler` is called for every callback invoked.
     ///
     /// This option provides an alternative for handling callbacks that
-    /// can doesn't require the handler to be `Send`, and `'static`.
+    /// don't require the handler to be `Send`, and `'static`.
     ///
     /// This should be called frequently (e.g. once per a frame)
-    /// in order to reduce the latency between recieving events.
+    /// in order to reduce the latency between receiving events.
     pub fn process_callbacks(&self, mut callback_handler: impl FnMut(CallbackResult)) {
         self.run_callbacks_raw(|cb_discrim, data| {
             {
@@ -246,7 +246,7 @@ impl Client {
     /// * The game isn't running on the same user/level as the steam client
     /// * The user doesn't own a license for the game.
     /// * The app ID isn't completely set up.
-    pub fn init() -> SIResult<Client> {
+    pub fn init() -> Result<Client, SteamAPIInitError> {
         static_assert_send::<Client>();
         static_assert_sync::<Client>();
         unsafe {
@@ -287,7 +287,7 @@ impl Client {
     /// * The game isn't running on the same user/level as the steam client
     /// * The user doesn't own a license for the game.
     /// * The app ID isn't completely set up.
-    pub fn init_app<ID: Into<AppId>>(app_id: ID) -> SIResult<Client> {
+    pub fn init_app<ID: Into<AppId>>(app_id: ID) -> Result<Client, SteamAPIInitError> {
         let app_id = app_id.into().0.to_string();
         std::env::set_var("SteamAppId", &app_id);
         std::env::set_var("SteamGameId", app_id);

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -48,7 +48,7 @@ impl LobbyId {
 impl Matchmaking {
     pub fn request_lobby_list<F>(&self, cb: F)
     where
-        F: FnOnce(SResult<Vec<LobbyId>>) + 'static + Send,
+        F: FnOnce(SteamResult<Vec<LobbyId>>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamMatchmaking_RequestLobbyList(self.mm);
@@ -85,7 +85,7 @@ impl Matchmaking {
     /// * `LobbyCreated`
     pub fn create_lobby<F>(&self, ty: LobbyType, max_members: u32, cb: F)
     where
-        F: FnOnce(SResult<LobbyId>) + 'static + Send,
+        F: FnOnce(SteamResult<LobbyId>) + 'static + Send,
     {
         assert!(max_members <= 250); // Steam API limits
         unsafe {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1153,15 +1153,15 @@ impl_callback!(cb: LobbyChatUpdate_t => LobbyChatUpdate {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LobbyCreated {
-    /// The result of the operation (EResult). Possible values: k_EResultOK, k_EResultFail, k_EResultTimeout, k_EResultLimitExceeded, k_EResultAccessDenied, k_EResultNoConnection
-    pub result: u32,
+    /// The result of the operation
+    pub result: SteamResult,
     /// The Steam ID of the lobby that was created, 0 if failed.
     pub lobby: LobbyId,
 }
 
 impl_callback!(cb: LobbyCreated_t => LobbyCreated {
     Self {
-        result: cb.m_eResult as u32,
+        result: to_steam_result(cb.m_eResult),
         lobby: LobbyId(cb.m_ulSteamIDLobby),
     }
 });

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -27,7 +27,7 @@ use crate::networking_types::{
     NetConnectionInfo, NetConnectionRealTimeInfo, NetworkingConnectionState, NetworkingIdentity,
     NetworkingMessage, SendFlags,
 };
-use crate::{register_callback, to_steam_result, Callback, Inner, SteamError};
+use crate::{Callback, Inner, SteamResult, register_callback, to_steam_result};
 use std::ffi::c_void;
 use std::sync::{Arc, Weak};
 
@@ -91,7 +91,7 @@ impl NetworkingMessages {
         send_type: SendFlags,
         data: &[u8],
         channel: u32,
-    ) -> Result<(), SteamError> {
+    ) -> SteamResult {
         let result = unsafe {
             sys::SteamAPI_ISteamNetworkingMessages_SendMessageToUser(
                 self.net,

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -27,7 +27,7 @@ use crate::networking_types::{
     NetConnectionInfo, NetConnectionRealTimeInfo, NetworkingConnectionState, NetworkingIdentity,
     NetworkingMessage, SendFlags,
 };
-use crate::{Callback, Inner, SteamResult, register_callback, to_steam_result};
+use crate::{register_callback, to_steam_result, Callback, Inner, SteamResult};
 use std::ffi::c_void;
 use std::sync::{Arc, Weak};
 

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -27,7 +27,7 @@ use crate::networking_types::{
     NetConnectionInfo, NetConnectionRealTimeInfo, NetworkingConnectionState, NetworkingIdentity,
     NetworkingMessage, SendFlags,
 };
-use crate::{register_callback, Callback, Inner, SteamError};
+use crate::{register_callback, to_steam_result, Callback, Inner, SteamError};
 use std::ffi::c_void;
 use std::sync::{Arc, Weak};
 
@@ -103,11 +103,7 @@ impl NetworkingMessages {
             )
         };
 
-        if result == sys::EResult::k_EResultOK {
-            return Ok(());
-        }
-
-        Err(result.into())
+        to_steam_result(result)
     }
 
     /// Reads the next message that has been sent from another user on the given channel.

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     SteamError,
 };
-use crate::{CallbackHandle, Inner, SResult};
+use crate::{CallbackHandle, Inner, SteamResult};
 #[cfg(test)]
 use serial_test::serial;
 use std::convert::TryInto;
@@ -395,7 +395,7 @@ impl NetworkingSockets {
     pub fn send_messages(
         &self,
         messages: impl IntoIterator<Item = NetworkingMessage>,
-    ) -> Vec<SResult<MessageNumber>> {
+    ) -> Vec<SteamResult<MessageNumber>> {
         let messages: Vec<_> = messages.into_iter().map(|x| x.take_message()).collect();
         let mut results = vec![0; messages.len()];
         unsafe {
@@ -512,7 +512,7 @@ impl ListenSocket {
     pub fn send_messages(
         &self,
         messages: impl IntoIterator<Item = NetworkingMessage>,
-    ) -> Vec<SResult<MessageNumber>> {
+    ) -> Vec<SteamResult<MessageNumber>> {
         let messages: Vec<_> = messages.into_iter().map(|x| x.take_message()).collect();
         let mut results = vec![0; messages.len()];
         unsafe {
@@ -724,7 +724,7 @@ impl NetConnection {
     /// socket, consider setting the options on the listen socket, since such options are
     /// inherited automatically.  If you really do need to set options that are connection
     /// specific, it is safe to set them on the connection before accepting the connection.
-    pub(crate) fn accept(mut self) -> SResult<()> {
+    pub(crate) fn accept(mut self) -> SteamResult {
         self.handle_connection();
         let result = unsafe {
             sys::SteamAPI_ISteamNetworkingSockets_AcceptConnection(self.sockets, self.handle)
@@ -860,7 +860,7 @@ impl NetConnection {
     ///   we were not ready to send it.
     /// - k_EResultLimitExceeded: there was already too much data queued to be sent.
     ///   (See k_ESteamNetworkingConfig_SendBufferSize)
-    pub fn send_message(&self, data: &[u8], send_flags: SendFlags) -> SResult<MessageNumber> {
+    pub fn send_message(&self, data: &[u8], send_flags: SendFlags) -> SteamResult<MessageNumber> {
         unsafe {
             let mut out_message_number = 0i64;
             let result = sys::SteamAPI_ISteamNetworkingSockets_SendMessageToConnection(
@@ -893,7 +893,7 @@ impl NetConnection {
     /// k_EResultInvalidState: connection is in an invalid state
     /// k_EResultNoConnection: connection has ended
     /// k_EResultIgnored: We weren't (yet) connected, so this operation has no effect.
-    pub fn flush_messages(&self) -> SResult<()> {
+    pub fn flush_messages(&self) -> SteamResult {
         unsafe {
             let result = sys::SteamAPI_ISteamNetworkingSockets_FlushMessagesOnConnection(
                 self.sockets,

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::networking_sockets::{InnerSocket, NetConnection};
 use crate::networking_types::NetConnectionError::UnhandledType;
-use crate::{Callback, Inner, SResult, SteamId};
+use crate::{Callback, Inner, SteamId, SteamResult};
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{c_void, CString};
 use std::fmt::{Debug, Display, Formatter};
@@ -1518,7 +1518,7 @@ impl ConnectionRequest {
         self.user_data
     }
 
-    pub fn accept(self) -> SResult<()> {
+    pub fn accept(self) -> SteamResult {
         self.connection.accept()
     }
 

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -222,12 +222,8 @@ impl SteamFile {
                         cb(Err(SteamError::IOFailure));
                         return;
                     }
-                    if v.m_eResult != sys::EResult::k_EResultOK {
-                        cb(Err(v.m_eResult.into()));
-                        return;
-                    }
 
-                    cb(Ok(v.m_hFile))
+                    cb(to_steam_result(v.m_eResult).map(|()| v.m_hFile))
                 },
             )
         }

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -308,7 +308,7 @@ impl std::io::Read for SteamFileReader {
                 &mut failed,
             );
 
-            if callback.m_eResult != sys::EResult::k_EResultOK {
+            if to_steam_result(callback.m_eResult).is_err() {
                 return Err(std::io::ErrorKind::Other.into());
             }
             let size = callback.m_cubRead as usize;

--- a/src/screenshots.rs
+++ b/src/screenshots.rs
@@ -128,10 +128,10 @@ pub struct ScreenshotReady {
 }
 
 impl_callback!(cb: ScreenshotReady_t => ScreenshotReady {
-    let local_handle = match cb.m_eResult {
-        sys::EResult::k_EResultOK => Ok(cb.m_hLocal),
-        sys::EResult::k_EResultIOFailure => Err(ScreenshotReadyError::Fail),
-        _ => Err(ScreenshotReadyError::Fail),
+    let local_handle = match to_steam_result(cb.m_eResult) {
+        Ok(_) => Ok(cb.m_hLocal),
+        Err(SteamError::IOFailure) => Err(ScreenshotReadyError::IoFailure),
+        Err(_) => Err(ScreenshotReadyError::Fail),
     };
 
     Self { local_handle }

--- a/src/server.rs
+++ b/src/server.rs
@@ -107,7 +107,7 @@ impl Server {
         query_port: u16,
         server_mode: ServerMode,
         version: &str,
-    ) -> SIResult<(Server, Client)> {
+    ) -> Result<(Server, Client), SteamAPIInitError> {
         unsafe {
             let version = CString::new(version).unwrap();
 
@@ -166,7 +166,7 @@ impl Server {
     /// thread.
     ///
     /// This should be called frequently (e.g. once per a frame)
-    /// in order to reduce the latency between recieving events.
+    /// in order to reduce the latency between receiving events.
     pub fn run_callbacks(&self) {
         self.inner.run_callbacks()
     }
@@ -177,10 +177,10 @@ impl Server {
     /// `callback_handler` is called for every callback invoked.
     ///
     /// This option provides an alternative for handling callbacks that
-    /// can doesn't require the handler to be `Send`, and `'static`.
+    /// don't require the handler to be `Send`, and `'static`.
     ///
     /// This should be called frequently (e.g. once per a frame)
-    /// in order to reduce the latency between recieving events.
+    /// in order to reduce the latency between receiving events.
     pub fn process_callbacks(&self, mut callback_handler: impl FnMut(CallbackResult)) {
         self.inner.process_callbacks(&mut callback_handler)
     }
@@ -196,7 +196,7 @@ impl Server {
     /// [`process_callbacks`] instead.
     ///
     /// [`run_callbacks`]: Self::run_callbacks
-    /// [`process_callbacks`]: Self::proceses_callbacks
+    /// [`process_callbacks`]: Self::process_callbacks
     pub fn register_callback<C, F>(&self, f: F) -> CallbackHandle
     where
         C: Callback,

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -496,10 +496,7 @@ impl_callback!(cb: DownloadItemResult_t => DownloadItemResult {
     Self {
         app_id: AppId(cb.m_unAppID),
         published_file_id: PublishedFileId(cb.m_nPublishedFileId),
-        error: match cb.m_eResult {
-            sys::EResult::k_EResultOK => None,
-            error => Some(error.into()),
-        },
+        error: to_steam_result(cb.m_eResult).err(),
     }
 });
 
@@ -513,10 +510,7 @@ pub struct DeleteItemResult {
 impl_callback!(cb: DeleteItemResult_t => DeleteItemResult {
     Self {
         published_file_id: PublishedFileId(cb.m_nPublishedFileId),
-        error: match cb.m_eResult {
-            sys::EResult::k_EResultOK | sys::EResult::k_EResultNone => None,
-            error => Some(error.into()),
-        },
+        error: to_steam_result(cb.m_eResult).err(),
     }
 });
 
@@ -818,10 +812,8 @@ impl UGC {
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultNone
-                        && v.m_eResult != sys::EResult::k_EResultOK
-                    {
-                        Err(v.m_eResult.into())
+                    } else if let Err(error) = to_steam_result(v.m_eResult) {
+                        Err(error)
                     } else {
                         Ok(())
                     })
@@ -847,8 +839,8 @@ impl UGC {
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultOK {
-                        Err(v.m_eResult.into())
+                    } else if let Err(error) = to_steam_result(v.m_eResult) {
+                        Err(error)
                     } else {
                         Ok(())
                     })
@@ -874,8 +866,8 @@ impl UGC {
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultOK {
-                        Err(v.m_eResult.into())
+                    } else if let Err(error) = to_steam_result(v.m_eResult) {
+                        Err(error)
                     } else {
                         Ok(())
                     })
@@ -897,8 +889,8 @@ impl UGC {
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultOK {
-                        Err(v.m_eResult.into())
+                    } else if let Err(error) = to_steam_result(v.m_eResult) {
+                        Err(error)
                     } else {
                         Ok(())
                     })
@@ -1114,13 +1106,13 @@ impl UpdateHandle {
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultOK {
-                        Err(v.m_eResult.into())
                     } else {
-                        Ok((
-                            PublishedFileId(v.m_nPublishedFileId),
-                            v.m_bUserNeedsToAcceptWorkshopLegalAgreement,
-                        ))
+                        to_steam_result(v.m_eResult).map(|()| {
+                            (
+                                PublishedFileId(v.m_nPublishedFileId),
+                                v.m_bUserNeedsToAcceptWorkshopLegalAgreement,
+                            )
+                        })
                     })
                 },
             );
@@ -1538,9 +1530,9 @@ impl QueryHandle {
                         sys::SteamAPI_ISteamUGC_ReleaseQueryUGCRequest(ugc, handle);
                         cb(Err(SteamError::IOFailure));
                         return;
-                    } else if v.m_eResult != sys::EResult::k_EResultOK {
+                    } else if let Err(error) = to_steam_result(v.m_eResult) {
                         sys::SteamAPI_ISteamUGC_ReleaseQueryUGCRequest(ugc, handle);
-                        cb(Err(v.m_eResult.into()));
+                        cb(Err(error));
                         return;
                     }
 

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -1699,7 +1699,7 @@ impl<'a> QueryResults<'a> {
             );
             debug_assert!(ok);
 
-            if raw_details.m_eResult != sys::EResult::k_EResultOK {
+            if to_steam_result(raw_details.m_eResult).is_err() {
                 return None;
             }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -249,13 +249,13 @@ pub struct AuthSessionTicketResponse {
     /// The ticket in question
     pub ticket: AuthTicket,
     /// The result of generating the ticket
-    pub result: SResult<()>,
+    pub result: SteamResult,
 }
 
 impl_callback!(cb: GetAuthSessionTicketResponse_t => AuthSessionTicketResponse {
     Self {
         ticket: AuthTicket(cb.m_hAuthTicket),
-        result: crate::to_steam_result(cb.m_eResult),
+        result: to_steam_result(cb.m_eResult),
     }
 });
 
@@ -287,7 +287,7 @@ fn test_auth_webapi() {
 #[derive(Debug)]
 pub struct TicketForWebApiResponse {
     pub ticket_handle: AuthTicket,
-    pub result: SResult<()>,
+    pub result: SteamResult,
     pub ticket_len: i32,
     pub ticket: Vec<u8>,
 }
@@ -295,7 +295,7 @@ pub struct TicketForWebApiResponse {
 impl_callback!(cb: GetTicketForWebApiResponse_t => TicketForWebApiResponse {
     Self {
         ticket_handle: AuthTicket(cb.m_hAuthTicket),
-        result: crate::to_steam_result(cb.m_eResult),
+        result: to_steam_result(cb.m_eResult),
         ticket_len: cb.m_cubTicket,
         ticket: cb.m_rgubTicket.to_vec(),
     }
@@ -386,12 +386,12 @@ impl_callback!(_cb: SteamServersConnected_t => SteamServersConnected {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamServersDisconnected {
     /// The reason we were disconnected from the Steam servers
-    pub reason: SteamError,
+    pub reason: SteamResult,
 }
 
 impl_callback!(cb: SteamServersDisconnected_t => SteamServersDisconnected {
     Self {
-        reason: cb.m_eResult.into(),
+        reason: to_steam_result(cb.m_eResult),
     }
 });
 
@@ -400,19 +400,19 @@ impl_callback!(cb: SteamServersDisconnected_t => SteamServersDisconnected {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SteamServerConnectFailure {
     /// The reason we failed to connect to the Steam servers
-    pub reason: SteamError,
+    pub reason: SteamResult,
     /// Whether we are still retrying the connection.
     pub still_retrying: bool,
 }
 
 impl_callback!(cb: SteamServerConnectFailure_t => SteamServerConnectFailure {
     Self {
-        reason: cb.m_eResult.into(),
+        reason: to_steam_result(cb.m_eResult),
         still_retrying: cb.m_bStillRetrying,
     }
 });
 
-/// Errors from `ValidateAuthTicketResponse`
+/// Errors from [`ValidateAuthTicketResponse`]
 #[derive(Clone, Debug, Error)]
 pub enum AuthSessionValidateError {
     /// The user in question is not connected to steam


### PR DESCRIPTION
Basically a more involved version of #329. Previously `SteamError` implemented `From<EResult>`, which could panic internally if the result was not an error. This is easy to make a mistake with and caused some downstream crashes (#327, #292, #291 I believe).

I've reworked the Error type a little bit, plus avoided duplicating the big matches with a macro. I'd like some opinions on this approach, is it a good decision or is it too hard to read?

Additionally SResult was renamed to `SteamResult`, plus few sites to actually use `to_steam_result`